### PR TITLE
feat: 최상위 예외 정의 및 예외 처리 구현

### DIFF
--- a/backend/src/main/java/org/mapleland/maplelanbackserver/exception/BadRequestException.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/exception/BadRequestException.java
@@ -1,0 +1,9 @@
+package org.mapleland.maplelanbackserver.exception;
+
+public class BadRequestException extends RuntimeException {
+    private static final String MESSAGE = "잘못된 요청입니다.";
+
+    public BadRequestException() {super(MESSAGE);}
+
+    public BadRequestException(String message) {super(message);}
+}

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/exception/ConflictException.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/exception/ConflictException.java
@@ -1,0 +1,10 @@
+package org.mapleland.maplelanbackserver.exception;
+
+public class ConflictException extends RuntimeException{
+    private static final String MESSAGE = "현재 리소스의 상태와 충돌합니다.";
+
+    public ConflictException() {super(MESSAGE);}
+
+    public ConflictException(String message) {super(message);}
+}
+

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/exception/ForbiddenException.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/exception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package org.mapleland.maplelanbackserver.exception;
+
+public class ForbiddenException extends RuntimeException{
+    private static final String MESSAGE = "해당 리소스에 접근할 권한이 없습니다.";
+
+    public ForbiddenException() {super(MESSAGE);}
+
+    public ForbiddenException(String message) {super(message);}
+}

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/exception/NotFoundException.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package org.mapleland.maplelanbackserver.exception;
+
+public class NotFoundException extends RuntimeException {
+    private static final String MESSAGE = "리소스를 찾을 수 없습니다.";
+
+    public NotFoundException() {super(MESSAGE);}
+
+    public NotFoundException(String message) {super(message);}
+}

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/exception/UnauthorizedException.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/exception/UnauthorizedException.java
@@ -1,7 +1,9 @@
 package org.mapleland.maplelanbackserver.exception;
 
 public class UnauthorizedException extends RuntimeException {
-    public UnauthorizedException(String message) {
-        super(message);
-    }
+    private static final String MESSAGE = "인증이 필요합니다.";
+
+    public UnauthorizedException() {super(MESSAGE);}
+
+    public UnauthorizedException(String message) {super(message);}
 }

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/exception/jari/JariNotFoundException.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/exception/jari/JariNotFoundException.java
@@ -1,0 +1,11 @@
+package org.mapleland.maplelanbackserver.exception.jari;
+
+import org.mapleland.maplelanbackserver.exception.NotFoundException;
+
+public class JariNotFoundException extends NotFoundException {
+    private static String MESSAGE = "해당 자리거래를 찾을 수 없습니다.";
+
+    public JariNotFoundException() {super(MESSAGE);}
+
+    public JariNotFoundException(String message) {super(message);}
+}

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/exception/report/DuplicateReportException.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/exception/report/DuplicateReportException.java
@@ -1,8 +1,11 @@
 package org.mapleland.maplelanbackserver.exception.report;
 
-public class DuplicateReportException extends ReportException{
+import org.mapleland.maplelanbackserver.exception.ConflictException;
 
-    public DuplicateReportException(String message) {
-        super(message);
-    }
+public class DuplicateReportException extends ConflictException {
+    private static final String MESSAGE = "신고는 중복될 수 없습니다.";
+
+    public DuplicateReportException() {super(MESSAGE);}
+
+    public DuplicateReportException(String message) {super(message);}
 }

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/exception/report/ReportNotFoundException.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/exception/report/ReportNotFoundException.java
@@ -1,0 +1,11 @@
+package org.mapleland.maplelanbackserver.exception.report;
+
+import org.mapleland.maplelanbackserver.exception.NotFoundException;
+
+public class ReportNotFoundException extends NotFoundException {
+    private static final String MESSAGE = "해당 신고를 찾을 수 없습니다.";
+
+    public ReportNotFoundException() {super(MESSAGE);}
+
+    public ReportNotFoundException(String message) {super(message);}
+}

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/exception/user/UserNotFoundException.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/exception/user/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package org.mapleland.maplelanbackserver.exception.user;
+
+import org.mapleland.maplelanbackserver.exception.NotFoundException;
+
+public class UserNotFoundException extends NotFoundException {
+    private static final String MESSAGE = "해당 사용자를 찾을 수 없습니다.";
+
+    public UserNotFoundException() {super(MESSAGE);}
+
+    public UserNotFoundException(String message) {super(message);}
+}

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/handler/GlobalExceptionHandler.java
@@ -1,0 +1,137 @@
+package org.mapleland.maplelanbackserver.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.mapleland.maplelanbackserver.exception.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 클라이언트의 요청이 잘못되었을 때 (예: 유효하지 않은 입력 값, 잘못된 요청 형식 등) 사용합니다.
+     * HTTP 상태 코드 400 Bad Request를 반환합니다.
+     */
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<Object> handleBadRequestException(BadRequestException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.BAD_REQUEST; // 400 Bad Request
+
+        return ResponseEntity.status(status).body(e.getMessage());
+    }
+
+    /**
+     * 인증되지 않은 사용자가 보호된 리소스에 접근하려고 할 때 사용합니다.
+     * (예: 로그인이 필요한 기능에 로그인 없이 접근)
+     * HTTP 상태 코드 401 Unauthorized를 반환합니다.
+     */
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<Object> handleAuthenticationException(UnauthorizedException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.UNAUTHORIZED; // 401 Unauthorized
+
+        return ResponseEntity.status(status).body(e.getMessage());
+    }
+
+    /**
+     * 인증은 되었지만 해당 자원에 대한 접근 권한이 없는 사용자가 접근하려고 할 때 사용합니다.
+     * (예: 관리자 권한이 필요한 기능에 일반 사용자가 접근)
+     * HTTP 상태 코드 403 Forbidden을 반환합니다.
+     */
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<Object> handleForbiddenException(ForbiddenException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.FORBIDDEN; // 403 Forbidden
+
+        return ResponseEntity.status(status).body(e.getMessage());
+    }
+
+    /**
+     * 요청한 리소스(데이터, 페이지 등)를 서버에서 찾을 수 없을 때 사용합니다.
+     * (예: 존재하지 않는 게시글 ID로 조회)
+     * HTTP 상태 코드 404 Not Found를 반환합니다.
+     */
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<Object> handleNotFoundException(NotFoundException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.NOT_FOUND; // 404 Not Found
+
+        return ResponseEntity.status(status).body(e.getMessage());
+    }
+
+    /**
+     * 요청이 서버의 현재 상태와 충돌될 때 사용합니다.
+     * (예: 중복된 데이터를 생성하려고 할 때)
+     * HTTP 상태 코드 409 Conflict를 반환합니다.
+     */
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<Object> handleConflictException(ConflictException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.CONFLICT; // 409 Conflict
+
+        return ResponseEntity.status(status).body(e.getMessage());
+    }
+
+    /**
+     * 위에 정의된 특정 예외 외의 모든 예상치 못한 서버 오류가 발생했을 때 사용합니다.
+     * (예: 데이터베이스 연결 오류, NullPointerException 등)
+     * HTTP 상태 코드 500 Internal Server Error를 반환합니다.
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleException(Exception e) {
+        log.error("Unhandled exception", e);
+
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR; // 500 Internal Server Error
+
+        return ResponseEntity.status(status).body(e.getMessage());
+    }
+
+    /**
+     * `@Valid` 또는 `@Validated` 어노테이션을 사용하여 요청 본문(request body)의 유효성 검사(validation)에 실패했을 때 사용합니다.
+     * HTTP 상태 코드 400 Bad Request를 반환하며, 어떤 필드에서 어떤 유효성 오류가 발생했는지 상세 정보를 포함합니다.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleValidationException(MethodArgumentNotValidException e) {
+        log.error(e.getMessage());
+
+        BindingResult bindingResult = e.getBindingResult();
+
+        HttpStatus status = HttpStatus.BAD_REQUEST; // 400 Bad Request
+
+        List<String> errorMessages = bindingResult.getFieldErrors().stream()
+                .map(fieldError -> String.format("[%s](은)는 %s 입력된 값: [%s]",
+                        fieldError.getField(),
+                        fieldError.getDefaultMessage(),
+                        fieldError.getRejectedValue()))
+                .toList();
+        return ResponseEntity.status(status).body(errorMessages);
+    }
+
+    /**
+     * HTTP 요청에 필수 파라미터(예: `@RequestParam`으로 선언된 파라미터)가 누락되었을 때 사용합니다.
+     * HTTP 상태 코드 400 Bad Request를 반환하며, 어떤 파라미터가 누락되었는지에 대한 정보를 포함합니다.
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<Object> handleMissingParam(MissingServletRequestParameterException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.BAD_REQUEST; // 400 Bad Request
+
+        List<String> errorMessages = List.of(e.getMessage());
+
+        return ResponseEntity.status(status).body(errorMessages);
+    }
+}

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/service/ReportService.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/service/ReportService.java
@@ -8,7 +8,9 @@ import org.mapleland.maplelanbackserver.dto.response.ReportDetailsListResponse;
 import org.mapleland.maplelanbackserver.dto.response.UserListResponse;
 import org.mapleland.maplelanbackserver.exception.NotFoundMapException;
 import org.mapleland.maplelanbackserver.exception.NotFoundUserException;
+import org.mapleland.maplelanbackserver.exception.jari.JariNotFoundException;
 import org.mapleland.maplelanbackserver.exception.report.DuplicateReportException;
+import org.mapleland.maplelanbackserver.exception.user.UserNotFoundException;
 import org.mapleland.maplelanbackserver.repository.ReportRepository;
 import org.mapleland.maplelanbackserver.repository.JariRepository;
 import org.mapleland.maplelanbackserver.repository.UserRepository;
@@ -47,10 +49,9 @@ public class ReportService {
 
 
         if (reportRepository.existsByReporterUserIdAndJariUserMapId(reporterId, request.getJariId())) {
-            throw new DuplicateReportException("중복 신고를 할 수 없습니다."); // DuplicatedReportException
-        }
-        Jari jari = jariRepository.OPTIONALFindByUserMapId(request.getJariId())
-                .orElseThrow(() -> new NotFoundMapException("등록된 게시글을 찾을 수 없습니다."));
+            throw new DuplicateReportException("중복 신고를 할 수 없습니다.");
+        };
+        Jari jari = jariRepository.OPTIONALFindByUserMapId(request.getJariId()).orElseThrow(JariNotFoundException::new);
 
         String s3ImageUrl = null;
 
@@ -62,13 +63,12 @@ public class ReportService {
 
         // 신고자
         User reporterUser = userRepository.findByUserId(reporterId).
-                orElseThrow(() -> new UsernameNotFoundException("신고 유저를 찾을 수 없습니다."));
+                orElseThrow(() -> new UserNotFoundException("신고 유저를 찾을 수 없습니다."));
 
         //신고된 유저
-        Jari reportedjari = jariRepository.OPTIONALFindByUserMapId(jari.getUserMapId()).orElseThrow(()
-                -> new NotFoundMapException("게시글을 찾을 수 없습니다."));
+        Jari reportedjari = jariRepository.OPTIONALFindByUserMapId(jari.getUserMapId()).orElseThrow(JariNotFoundException::new);
 
-        User reportedUser = userRepository.findByUserId(reportedjari.getUser().getUserId()).orElseThrow(() -> new NotFoundUserException("사용자를 찾을 수 없습니다."));
+        User reportedUser = userRepository.findByUserId(reportedjari.getUser().getUserId()).orElseThrow(UserNotFoundException::new);
 
 
         Report report = Report.builder()


### PR DESCRIPTION
## 📝 개요
* 커스텀 예외들이 상속받아서 사용할 최상위 예외 정의 및 예외 처리 구현을 하였습니다.
* 신고 기능에서 발생하는 예외들을 커스텀 예외로 처리되도록 변경했습니다.

## ✨ 상세 내용
* 공통 예외
  * `BadRequestException` : 400 Bad Request (클라이언트의 요청이 잘못되었을 때)
  * `MethodArgumentNotValidException` : 400 Bad Reqeust (요청 본문의 유효성 검사 실패 시)
  * `MissingServletRequestParameterException` : 400 Bad Request (필수 요청 파라미터 누락 시)
  * `UnauthorizedException` : 401 Unauthorized (인증되지 않음)
  * `ForbiddenException` : 403 Forbidden (접근 권한 없음)
  * `NotFoundException` : 404 Not Found (요청한 리소스를 찾을 수 없을 때)
  * `ConflictException` : 409 Conflict (요청이 서버의 현재 자원 상태와 충돌될 때)
 
커스텀 예외를 구현하실 때 위의 공통 예외 중 하나를 상속받아 구현하시면 됩니다(필요 시 공통 예외를 추가하셔도 됩니다).

## 🔗 관련 이슈
This closes #35 
