### PR TITLE
feat: 사용자를 검색하는 API 구현

### DIFF
--- a/backend/src/main/java/org/mapleland/maplelanbackserver/controller/admincontroller/AdminController.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/controller/admincontroller/AdminController.java
@@ -4,18 +4,16 @@ import lombok.RequiredArgsConstructor;
 import org.mapleland.maplelanbackserver.dto.BanUserRequest;
 import org.mapleland.maplelanbackserver.dto.report.ReportedPostWithReasonsDto;
 import org.mapleland.maplelanbackserver.dto.response.*;
+import org.mapleland.maplelanbackserver.dto.user.UserResponse;
 import org.mapleland.maplelanbackserver.service.MapService;
 import org.mapleland.maplelanbackserver.service.ReportService;
 import org.mapleland.maplelanbackserver.service.UserService;
 import org.mapleland.maplelanbackserver.service.WebSocketService;
-import org.mapleland.maplelanbackserver.table.User;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -27,6 +25,7 @@ public class AdminController {
     private final UserService userService;
     private final MapService mapService;
     private final WebSocketService webSocketService;
+
     @GetMapping("/api/admin/users")
     public ResponseEntity<List<UserListResponse>> findAllUsersOrderByReportCount(@RequestParam(defaultValue = "0") int page) {
         List<UserListResponse> allUsersOrderByReportCount = reportService.findAllUsersOrderByReportCount(page);
@@ -40,41 +39,52 @@ public class AdminController {
     }
 
     @PostMapping("/api/admin/userBan")
-    public ResponseEntity<Map<String,String>> banUser(@RequestBody BanUserRequest request) {
+    public ResponseEntity<Map<String, String>> banUser(@RequestBody BanUserRequest request) {
 
         userService.userBan(request);
         return ResponseEntity.status(HttpStatus.OK).body(Map.of(
-                "status","200",
+                "status", "200",
                 "message", "유저가 정상적으로 차단 되었음"
         ));
     }
 
     @PostMapping("/api/admin/userUnBan/{userId}")
-    public ResponseEntity<Map<String,String>> unBanUser(@PathVariable Integer userId) {
+    public ResponseEntity<Map<String, String>> unBanUser(@PathVariable Integer userId) {
         userService.userUnban(userId);
         return ResponseEntity.status(HttpStatus.OK).body(Map.of(
-                "status","200",
+                "status", "200",
                 "message", "유저가 정상적으로 풀렸음"
         ));
     }
+
     @GetMapping("/api/admin/users/count")
     public ResponseEntity<?> countUsers() {
         int userCount = userService.userAllCount();
         return ResponseEntity.status(HttpStatus.OK).body(userCount);
     }
+
     @GetMapping("/api/admin/users/signup-count")
     public ResponseEntity<List<ResponseAllUserDto>> getSignupCountPerDay(@RequestParam int year, @RequestParam int month) {
         List<ResponseAllUserDto> signupCountPerDay = userService.getSignupCountPerDay(year, month);
         return ResponseEntity.status(HttpStatus.OK).body(signupCountPerDay);
     }
+
     @GetMapping("/api/admin/users/banned")
-    public ResponseEntity<List<ResponseBannedUserDto>>  lockedUsers() {
+    public ResponseEntity<List<ResponseBannedUserDto>> lockedUsers() {
         List<ResponseBannedUserDto> responseBannedUserDtos = userService.callLockedUser();
         return ResponseEntity.status(HttpStatus.OK).body(responseBannedUserDtos);
     }
+
     @GetMapping("/api/admin/reports/posts")
     public ResponseEntity<Page<ReportedPostWithReasonsDto>> reportsPosts(@RequestParam(defaultValue = "0") int page) {
         Page<ReportedPostWithReasonsDto> reportedPostWithReasonsDtos = userService.AllReportPosts(page);
         return ResponseEntity.ok(reportedPostWithReasonsDtos);
     }
+
+    @GetMapping("/api/admin/users/search")
+    public ResponseEntity<List<UserResponse>> findUsers(@RequestParam String globalName) {
+        List<UserResponse> response = userService.findUsersByGlobalName(globalName);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/dto/user/UserResponse.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/dto/user/UserResponse.java
@@ -11,6 +11,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Getter
 public class UserResponse {
+    int userId;
+
     String discordId;
 
     String image;
@@ -29,6 +31,7 @@ public class UserResponse {
 
     public static UserResponse from(User user) {
         return new UserResponse(
+                user.getUserId(),
                 user.getDiscordId(),
                 user.getImage(),
                 user.getCreateTime(),

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/repository/UserRepository.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/repository/UserRepository.java
@@ -55,5 +55,5 @@ public interface UserRepository extends JpaRepository<User, Integer> {
     ORDER BY u.bannedHours DESC
 """) List<ResponseBannedUserDto> findBannedUsersDto();
 
-
+    List<User> findByGlobalNameContaining(String globalName);
 }

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/service/UserService.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/service/UserService.java
@@ -237,5 +237,13 @@ public class UserService {
         return new PageImpl<>(content, pageable, total);
     }
 
-
+    public List<UserResponse> findUsersByGlobalName(String globalName) {
+        List<User> users;
+        if (globalName == null || globalName.isEmpty()) {
+            users = userRepository.findAll();
+        } else {
+            users = userRepository.findByGlobalNameContaining(globalName); // 부분 일치
+        }
+        return users.stream().map(UserResponse::from).toList();
+    }
 }


### PR DESCRIPTION
## 📝 개요
어드민페이지에서 사용할 `사용자 검색 API` 를 구현하였습니다.
* 관리자 권한이 필요합니다.
* `globalName` 으로 검색을 합니다.

## ✨ 상세 내용
* 인자로받은 `globalName` 을 포함하는 `globalName` 을 가진 사용자 리스트를 반환합니다.

## 📌 기타
* 현재 `UserService` 에 트랜잭션이 걸려있지 않습니다.
  * 다른 `Service` 들에도 몇몇 제외하고 트랜잭션이 걸려있지 않은 것을 확인했습니다.
* `globalName` 에 인덱스를 걸 시 조금 더 빠르게 검색할 수 있습니다. 

## 🔗 관련 이슈
This closes #40 
