### PR TITLE
자리 업데이트 기능 수정

### DIFF
--- a/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
@@ -338,24 +338,20 @@ public class MapService {
         //jwt 유저 토큰 아이디
         int userId = JwtUtil.getUserId(token);
 
-        Jari byUserMapId = registerRepository.findByUserMapId(jariUpdateRequest.mapId());
-        if (byUserMapId == null) {
+        Jari jari = jariRepository.findByUserMapId(jariUpdateRequest.mapId());
+        if (jari == null) {
             throw new NotFoundMapException("존재하지 않는 mapId입니다: " + jariUpdateRequest.mapId());
         }
-        Jari jariId = jariRepository.findByUserMapId(jariUpdateRequest.mapId());
 
+        jari.validateOwner(userId);
 
-        if(userId != jariId.getUserMapId()) throw new UserMismatchException("사용자가 다릅니다.");
-
-        byUserMapId.setServerColor(jariUpdateRequest.serverColor());
-        byUserMapId.setPrice(jariUpdateRequest.price());
-        byUserMapId.setNegotiationOption(jariUpdateRequest.negotiationOption());
-        byUserMapId.setComment(jariUpdateRequest.comment());
-
-        registerRepository.save(byUserMapId);
-
+        jari.update(
+                jariUpdateRequest.serverColor(),
+                jariUpdateRequest.price(),
+                jariUpdateRequest.negotiationOption(),
+                jariUpdateRequest.comment()
+        );
     }
-
 
     public void mapUpdatePrice(PriceUpdateRequest priceDto) {
         Jari byUserId = registerRepository.findByUserMapId(priceDto.mapId());

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/table/Jari.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/table/Jari.java
@@ -68,4 +68,11 @@ public class Jari {
     public boolean validateOwner(Integer userId) {
         return this.user.getUserId().equals(userId);
     }
+
+    public void update(String serverColor, int price, Boolean negotiationOption, String comment) {
+        this.serverColor = serverColor;
+        this.price = price;
+        this.negotiationOption = negotiationOption;
+        this.comment = comment;
+    }
 }


### PR DESCRIPTION
## 📝 개요
요청한 사용자의 `userId` 와 해당 자리의 생성자의 `userId` 와 비교해야 하는데 현재 `userMapId` 와 비교를 하고 있기에 수정하였습니다.

## ✨ 상세 내용
* `findByUserMapId` 가 중복사용되고있기에 이 부분을 수정했습니다.
* `setter` 대신 `Jari` 엔티티 클래스 안에 `update()` 메서드를 구현하여 수정하도록 했습니다.

## 🔗 관련 이슈
This closes #52 
