### PR TITLE
fix: 신고 이미지 올릴떄 이미지 파일인지 확인

### DIFF
--- a/frontend/src/feature/report/hooks/useReportDialog.ts
+++ b/frontend/src/feature/report/hooks/useReportDialog.ts
@@ -41,6 +41,17 @@ export const useReportDialog = (
       const maxSizeMB = 10;
       const maxSizeBytes = maxSizeMB * 1024 * 1024;
 
+      // 1. 이미지 파일인지 확인
+      if (!file.type.startsWith("image/")) {
+        toast({
+          title: "❌ 업로드 실패",
+          description: "이미지 파일만 업로드할 수 있습니다.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      // 2. 용량 제한 확인
       if (file.size > maxSizeBytes) {
         toast({
           title: "❌ 업로드 실패",


### PR DESCRIPTION
## 📝 개요
신고 이미지 올릴떄 이미지 파일인지 확인

## ✨ 상세 내용
신고 이미지 올릴떄 이미지 파일인지 확인 만약 안되면 toast로 알려줌

## 📌 기타
참고해야 할 사항, 스크린샷, 논의점 등

## 🔗 관련 이슈
이슈번호, 관련 링크 등
