### PR TITLE
fix: 자리 등록 후 jariList 동기화 안 되던 문제 해결

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
-# VITE_API_BASE_URL=https://bug-known-goblin.ngrok-free.app
-VITE_API_BASE_URL= https://mashop.kr
+VITE_API_BASE_URL=https://bug-known-goblin.ngrok-free.app
+# VITE_API_BASE_URL= https://mashop.kr

--- a/frontend/src/feature/popularJari/ui/PopularJariGrid.tsx
+++ b/frontend/src/feature/popularJari/ui/PopularJariGrid.tsx
@@ -10,6 +10,7 @@ const PopularJariGrid = () => {
     const load = async () => {
       try {
         const data = await getPopularJari();
+        console.log(data);
         setPopularMaps(data);
       } catch (err) {
         console.error("인기 맵 로딩 실패:", err);

--- a/frontend/src/feature/register/hooks/useJariRegisterForm.ts
+++ b/frontend/src/feature/register/hooks/useJariRegisterForm.ts
@@ -7,6 +7,7 @@ import {
   registerJari,
 } from "@/entity/jari/api/registerJari";
 import { toast } from "@/shared/hooks/use-toast";
+import { useQueryClient } from "@tanstack/react-query";
 
 type TradeType = "SELL" | "BUY";
 type ServerColor = "Red" | "Yellow" | "Green";
@@ -22,6 +23,8 @@ interface FormState {
 
 export const useJariRegisterForm = () => {
   const { name } = useParams();
+  const queryClient = useQueryClient();
+
   const user = useUser();
   const navigate = useNavigate();
   const [mapData, setMapData] = useState<MapItem | null>(null);
@@ -96,12 +99,14 @@ export const useJariRegisterForm = () => {
 
     try {
       await registerJari(payload);
+
       toast({
         title: "자리 등록 완료",
         variant: "success",
         description: "성공적으로 등록되었습니다.",
       });
       navigate(`/jari/${form.mapName}`);
+      queryClient.invalidateQueries({ queryKey: ["jariList"] });
       setForm((prev) => ({
         ...prev,
         tradeType: null,


### PR DESCRIPTION
## 📝 개요
자리 등록 후 /jari/:mapName 페이지로 이동했을 때,
방금 등록한 글이 리스트에 표시되지 않는 문제를 해결합니다.

## ✨ 상세 내용
- `registerJari` API 호출 후 `queryClient.invalidateQueries(["jariList", mapName])`를 추가하여
  React Query의 캐시를 무효화하고 최신 데이터를 다시 불러오도록 처리했습니다.
- 이를 통해 `/jari/:mapName` 페이지 진입 시 최신 글이 반영됩니다.

## 📌 기타
- 관련 이슈: Closes #65
- 새로고침 없이도 등록한 글이 바로 보이는 UX 개선 목적
