### PR TITLE
fix: 쓸데없는 console.log 제거 및 시간표시 버그날수 있는 부분 보완

### DIFF
--- a/frontend/src/feature/delete/api/deleteJari.ts
+++ b/frontend/src/feature/delete/api/deleteJari.ts
@@ -2,7 +2,7 @@ import { API_BASE_URL } from "@/shared/config/api";
 
 export async function deleteJari(mapId: number) {
   const token = localStorage.getItem("accessToken");
-  console.log(token);
+
   if (!token) {
     throw new Error("로그인이 필요합니다.");
   }

--- a/frontend/src/feature/popularJari/ui/PopularJariGrid.tsx
+++ b/frontend/src/feature/popularJari/ui/PopularJariGrid.tsx
@@ -10,7 +10,7 @@ const PopularJariGrid = () => {
     const load = async () => {
       try {
         const data = await getPopularJari();
-        console.log(data);
+
         setPopularMaps(data);
       } catch (err) {
         console.error("인기 맵 로딩 실패:", err);

--- a/frontend/src/feature/trade/ui/TradeCardHeader.tsx
+++ b/frontend/src/feature/trade/ui/TradeCardHeader.tsx
@@ -4,7 +4,7 @@ import { formatDistanceToNow } from "date-fns";
 import { ko } from "date-fns/locale";
 import mesoIcon from "@/shared/assets/icon/mesoIcon.webp";
 import AdminKebabMenu from "@/feature/delete/ui/DeleteKebabMenu";
-
+import { toZonedTime } from "date-fns-tz";
 interface Props {
   mapName: string;
   price: number;
@@ -32,9 +32,7 @@ export const TradeCardHeader = ({
   refetch,
   mapId,
 }: Props) => {
-  const koreaTime = new Date(
-    new Date(createTime).getTime() + 9 * 60 * 60 * 1000
-  );
+  const koreaTime = toZonedTime(createTime, "Asia/Seoul");
 
   return (
     <div className="flex items-center justify-center gap-3 w-full">


### PR DESCRIPTION
## 📝 개요
formatDistanceToNow에서 한국 시간 변환 시 "1분 미만 후"와 같이 잘못된 시간 표시가 나타나는 문제를 해결합니다.
createTime과 비교 기준인 now를 모두 KST로 통일하여, 상대 시간이 올바르게 "방금 전" 또는 "몇 분 전" 등으로 출력되도록 수정했습니다.


## ✨ 상세 내용
기존에는 toZonedTime(createTime, "Asia/Seoul")만 적용했기 때문에 현재 시간(new Date())과 시간대가 달라 "후"로 출력되는 문제가 있었습니다.
이를 해결하기 위해 toZonedTime(new Date(), "Asia/Seoul")로 현재 시간도 변환한 뒤, formatDistanceToNow에 now 인자를 직접 전달했습니다.
formatDistanceToNow는 내부적으로 Date.now()를 쓰기 때문에 비교 기준을 명시하지 않으면 타임존 차이로 오동작 가능성이 있습니다.

## 📌 기타
참고해야 할 사항, 스크린샷, 논의점 등

## 🔗 관련 이슈
closes #69