### PR TITLE
파비콘 노출 잘되도록 shortcut icon 추가했습니다

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,7 +17,12 @@
       gtag("config", "G-YNNY5M1EPN");
     </script>
     <!-- Favicon -->
-    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+    <link rel="icon" href="https://mashop.kr/favicon.ico" type="image/x-icon" />
+    <link
+      rel="shortcut icon"
+      href="https://mashop.kr/favicon.ico"
+      type="image/x-icon"
+    />
 
     <!-- 웹폰트: Inter -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## 📝 개요
파비콘이 구글과 네이버에 노출되지 않는 문제가 발생하였습니다.
## ✨ 상세 내용
파비콘이 구글과 네이버에 노출이 되지 않아 코드를 더 추가했습니다.

## 📌 기타
참고해야 할 사항, 스크린샷, 논의점 등

## 🔗 관련 이슈
close #81 
