### PR TITLE
fix: price 그래프 시간 UTC로 보이는것 발견 및 수정

### DIFF
--- a/frontend/src/feature/price/ui/PriceChart.tsx
+++ b/frontend/src/feature/price/ui/PriceChart.tsx
@@ -27,13 +27,15 @@ interface Props {
 }
 
 export const PriceChart = ({ data }: Props) => {
-  const labels = data.map((d) =>
-    new Date(d.dateTime).toLocaleTimeString("ko-KR", {
+  const labels = data.map((d) => {
+    const utc = new Date(d.dateTime);
+    const kst = new Date(utc.getTime() + 9 * 60 * 60 * 1000); // +9시간
+    return kst.toLocaleTimeString("ko-KR", {
       hour: "2-digit",
       minute: "2-digit",
       hour12: false,
-    })
-  );
+    });
+  });
 
   const prices = data.map((d) => d.price);
 


### PR DESCRIPTION
## 📝 개요
fix: price 그래프 시간 UTC로 보이는것 발견 및 수정

## ✨ 상세 내용
한국시간으로 +9시간 해서 변경

## 📌 기타
참고해야 할 사항, 스크린샷, 논의점 등

## 🔗 관련 이슈
close #84 
