### PR TITLE
입력값 검증 예외 메시지 출력 리팩터링

### DIFF
--- a/backend/src/main/java/org/mapleland/maplelanbackserver/dto/Map/JariCreatedRequest.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/dto/Map/JariCreatedRequest.java
@@ -30,7 +30,7 @@ import org.mapleland.maplelanbackserver.enumType.TradeType;
       @Positive(message = "가격은 양수여야 합니다.")
       @Max(value = 2000000000, message = "가격은 최대 20억까지 입력 가능합니다.")
       @Schema(description = "등록 가격 (단위: 메소)", example = "50000000")
-      private Integer price;
+      private Long price;
 
       @NotNull(message = "흥정 옵션을 선택하세요.")
       @Schema(description = "흥정 가능 여부", example = "false")

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/handler/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.mapleland.maplelanbackserver.exception.notfound.NotFoundException;
 import org.mapleland.maplelanbackserver.exception.unauthorization.UnauthorizedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -120,7 +121,7 @@ public class GlobalExceptionHandler {
 
         if (bindingResult.hasErrors() && !bindingResult.getFieldErrors().isEmpty()) {
             FieldError firstError = bindingResult.getFieldErrors().get(0);
-            errorMessage = String.format("[%s](은)는 %s 입력된 값: [%s]",
+            errorMessage = String.format("%s: %s (입력된 값: %s)",
                     firstError.getField(),
                     firstError.getDefaultMessage(),
                     firstError.getRejectedValue());
@@ -144,5 +145,11 @@ public class GlobalExceptionHandler {
         List<String> errorMessages = List.of(e.getMessage());
 
         return ResponseEntity.status(status).body(errorMessages);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Object> handleParseException(HttpMessageNotReadableException e) {
+        String errorMessage = "잘못된 요청 데이터입니다.";
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage);
     }
 }


### PR DESCRIPTION
## 📝 개요
현재 가격의 입력값이 21억을 넘어갈 시 예외메시지가 이상하게 출력됩니다.

이 부분을 보기좋게 출력되도록 수정하였습니다.

## ✨ 상세 내용
* `@Valid` 검증에서 걸릴 시 `%s: %s (입력된 값: %s)` 형태로 출력 하도록 수정
* 자료형의 범위를 넘는 값이 들어올 시 `잘못된 요청 데이터입니다.` 를 출력하도록 코드 추가

## 🔗 관련 이슈
This closes #95 
