### PR TITLE
refactor: popularjari api 호출 빈도 줄이기

### DIFF
--- a/frontend/src/entity/jari/hooks/usePopularJari.ts
+++ b/frontend/src/entity/jari/hooks/usePopularJari.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { getPopularJari } from "../api/getPopularJari";
+
+export const usePopularJari = () => {
+  return useQuery({
+    queryKey: ["popularJari"],
+    queryFn: getPopularJari,
+    staleTime: 1000 * 60 * 9, // 9분 (백엔드와 오차 보정)
+  });
+};

--- a/frontend/src/feature/popularJari/ui/PopularJariGrid.tsx
+++ b/frontend/src/feature/popularJari/ui/PopularJariGrid.tsx
@@ -1,30 +1,13 @@
-import { useEffect, useState } from "react";
-import { getPopularJari, PopularMap } from "@/entity/jari/api/getPopularJari";
 import { JariCard } from "@/feature/popularJari/ui/PopularJariCard";
+import { usePopularJari } from "@/entity/jari/hooks/usePopularJari";
 
 const PopularJariGrid = () => {
-  const [popularMaps, setPopularMaps] = useState<PopularMap[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const data = await getPopularJari();
-
-        setPopularMaps(data);
-      } catch (err) {
-        console.error("인기 맵 로딩 실패:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
-  }, []);
+  const { data: popularMaps = [], isLoading } = usePopularJari();
 
   return (
     <div className=" p-4 mb:p-8 rounded-lg bg-neutral-700">
       <h2 className="text-xl font-bold mb-5">🔥 인기 자리</h2>
-      {loading ? (
+      {isLoading ? (
         <p className="text-white text-center">로딩 중...</p>
       ) : (
         <div className="grid grid-cols-1 mb:grid-cols-2 sm:grid-cols-3 gap-3 lg:gap-5 px-1  ">


### PR DESCRIPTION
## 📝 개요
popularjari api 호출 빈도 줄이기

## ✨ 상세 내용
- 프론트는 popularJari 데이터를 React Query를 통해 불러올 때,
  - `staleTime`을 적절히 설정하여 **9분 동안은 캐시된 데이터 사용**
  - **불필요한 요청 없이** 백엔드 갱신 주기와 동기화

## 📌 기타
참고해야 할 사항, 스크린샷, 논의점 등

## 🔗 관련 이슈
close #105 
