### PR TITLE
fix: submitreport부분 err 제대로 못 받아오는 부분 수정

### DIFF
--- a/frontend/src/feature/report/api/submitReport.ts
+++ b/frontend/src/feature/report/api/submitReport.ts
@@ -14,7 +14,6 @@ export async function submitReport(payload: ReportPayload) {
       throw new Error("인증 토큰이 없습니다.");
     }
 
-    // JSON 데이터를 하나의 Blob으로 감싸 request라는 key로 FormData에 추가
     const requestPayload = {
       reason: payload.reason,
       userId: payload.userId,
@@ -41,14 +40,10 @@ export async function submitReport(payload: ReportPayload) {
       body: formData,
     });
 
-    const data = await res.json();
-
     if (!res.ok) {
-      const errorJson = await res.text();
-      throw errorJson;
+      const errorText = await res.text();
+      throw errorText;
     }
-
-    return data;
   } catch (error) {
     console.error("신고 요청 실패:", error);
     throw error;


### PR DESCRIPTION
## 📝 개요
서버에서 에러 응답을 문자열로 반환할 경우, 클라이언트에서 메시지를 제대로 표시하지 못하는 문제를 해결하였습니다.

## ✨ 상세 내용
기존에는 res.json()으로 에러 응답을 처리했으나, 서버가 단순 문자열을 반환할 경우 오류 발생

이를 res.text()로 변경하여 문자열을 그대로 throw하도록 수정

catch 블록에서는 typeof err === "string" 체크로 사용자에게 정확한 메시지를 toast로 노출

예외 처리 로직은 ReportButton.tsx 내부 handleSubmitReport 함수에 적용



## 📌 기타
참고해야 할 사항, 스크린샷, 논의점 등

## 🔗 관련 이슈
close #125