### PR TITLE
모든 자리 거래 조회 API 구현

### DIFF
--- a/backend/src/main/java/org/mapleland/maplelanbackserver/controller/admincontroller/AdminController.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/controller/admincontroller/AdminController.java
@@ -10,6 +10,9 @@ import org.mapleland.maplelanbackserver.service.ReportService;
 import org.mapleland.maplelanbackserver.service.UserService;
 import org.mapleland.maplelanbackserver.service.WebSocketService;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,6 +26,7 @@ public class AdminController {
 
     private final ReportService reportService;
     private final UserService userService;
+    private final MapService mapService;
 
     @GetMapping("/api/admin/users")
     public ResponseEntity<List<UserListResponse>> findAllUsersOrderByReportCount(@RequestParam(defaultValue = "0") int page) {
@@ -82,6 +86,12 @@ public class AdminController {
     @GetMapping("/api/admin/users/search")
     public ResponseEntity<List<UserResponse>> findUsers(@RequestParam String globalName) {
         List<UserResponse> response = userService.findUsersByGlobalName(globalName);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/api/admin/jari")
+    public ResponseEntity<JariListResponse> findAllJari(@PageableDefault(size = 10, sort = "createTime", direction = Sort.Direction.DESC) Pageable pageable) {
+        JariListResponse response = mapService.findAllJari(pageable);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/dto/Map/JariResponse.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/dto/Map/JariResponse.java
@@ -3,6 +3,7 @@ package org.mapleland.maplelanbackserver.dto.Map;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.mapleland.maplelanbackserver.enumType.Region;
 import org.mapleland.maplelanbackserver.enumType.TradeType;
+import org.mapleland.maplelanbackserver.table.Jari;
 
 import java.time.LocalDateTime;
 @Schema(description = "맵 정보 Dto")
@@ -22,4 +23,25 @@ public record JariResponse(
         int userId,
         String discordId,
         boolean isCompleted
-) {}
+) {
+
+    public static JariResponse from(Jari jari) {
+        return new JariResponse(
+                jari.getUserMapId(),
+                jari.getMapName(),
+                jari.getServerColor(),
+                jari.getPrice(),
+                jari.getTradeType(),
+                jari.getNegotiationOption(),
+                jari.getArea(),
+                jari.getCreateTime(),
+                jari.getComment(),
+                jari.getMonsterImageUrl(),
+                jari.getUser().getGlobalName(),
+                jari.getUser().getImage(),
+                jari.getUser().getUserId(),
+                jari.getUser().getDiscordId(),
+                jari.getIsCompleted()
+        );
+    }
+}

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/dto/response/JariListResponse.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/dto/response/JariListResponse.java
@@ -1,0 +1,30 @@
+package org.mapleland.maplelanbackserver.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.mapleland.maplelanbackserver.dto.Map.JariResponse;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class JariListResponse {
+    private List<JariResponse> jariList;
+    private int currentPage;
+    private int totalPage;
+    private long totalElements;
+    private int pageSize;
+
+    public static JariListResponse from(Page<JariResponse> page) {
+        return new JariListResponse(
+                page.getContent(),
+                page.getNumber(),
+                page.getTotalPages(),
+                page.getTotalElements(),
+                page.getSize()
+        );
+    }
+}

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
@@ -7,6 +7,7 @@ import org.mapleland.maplelanbackserver.dto.Map.*;
 import org.mapleland.maplelanbackserver.dto.response.DropItemResponse;
 import org.mapleland.maplelanbackserver.dto.request.JariUpdateRequest;
 import org.mapleland.maplelanbackserver.dto.request.JariIsCompletedRequest;
+import org.mapleland.maplelanbackserver.dto.response.JariListResponse;
 import org.mapleland.maplelanbackserver.dto.response.PriceStatDto;
 import org.mapleland.maplelanbackserver.dto.update.PriceUpdateRequest;
 import org.mapleland.maplelanbackserver.dto.update.ServerColorRequest;
@@ -20,7 +21,6 @@ import org.mapleland.maplelanbackserver.exception.notfound.jari.NotFoundMapExcep
 import org.mapleland.maplelanbackserver.exception.notfound.jari.NotFoundMapTicketException;
 import org.mapleland.maplelanbackserver.exception.notfound.jari.NotFoundUserException;
 import org.mapleland.maplelanbackserver.exception.unauthorization.UserMismatchException;
-import org.mapleland.maplelanbackserver.filter.AdminCheckFilter;
 import org.mapleland.maplelanbackserver.jwtUtil.JwtUtil;
 import org.mapleland.maplelanbackserver.repository.*;
 import org.mapleland.maplelanbackserver.resolve.RegionResolver;
@@ -28,7 +28,9 @@ import org.mapleland.maplelanbackserver.table.*;
 import org.mapleland.maplelanbackserver.utilmethod.UtilMethod;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.net.URLEncoder;
@@ -482,5 +484,10 @@ public class MapService {
 
         jari.bump(now);
 
+    }
+
+    public JariListResponse findAllJari(Pageable pageable) {
+        Page<JariResponse> jariResponsePage = jariRepository.findAll(pageable).map(JariResponse::from);
+        return JariListResponse.from(jariResponsePage);
     }
 }


### PR DESCRIPTION
## 📝 개요
관리자페이지에서 사용할 모든 자리 거래 조회 API를 구현하였습니다.

## ✨ 상세 내용
`Pageable` 을 사용하여 간단하게 페이징하여 제공합니다.

## 🔗 관련 이슈
This closes #128 
