### PR TITLE
refactor: 오토컴플리트api 리무브 및 그 대신 useallmaps씀

### DIFF
--- a/frontend/src/feature/jari/ui/JariMiniMapCard.tsx
+++ b/frontend/src/feature/jari/ui/JariMiniMapCard.tsx
@@ -2,7 +2,7 @@
 
 import { Link } from "react-router-dom";
 import { Button } from "@/shared/ui/button/Button";
-import { MapItem } from "@/entity/jari/api/autocomplete";
+import { MapItem } from "@/entity/map/api/getAllMaps";
 import { AlertButton } from "@/feature/alert/ui/AlertButton";
 import { useUser } from "@/entity/user/hooks/useUser";
 

--- a/frontend/src/feature/trade/hooks/useJariDetailData.ts
+++ b/frontend/src/feature/trade/hooks/useJariDetailData.ts
@@ -1,10 +1,12 @@
 import { useState, useCallback, useEffect } from "react";
-import { fetchAutocomplete, MapItem } from "@/entity/jari/api/autocomplete";
+import { useAllMaps } from "@/entity/map/hooks/useAllMaps";
+import { MapItem } from "@/entity/map/api/getAllMaps";
 import { DropItem } from "@/entity/jari/api/getMonsterInfo";
 import { DailyPriceStat } from "@/feature/price/model/type";
 import { API_BASE_URL } from "@/shared/config/api";
 
 export const useJariDetailData = (name: string | undefined) => {
+  const { data: allMaps } = useAllMaps();
   const [mapMeta, setMapMeta] = useState<MapItem | null>(null);
   const [dropItems, setDropItems] = useState<DropItem[]>([]);
   const [priceStats, setPriceStats] = useState<DailyPriceStat[]>([]);
@@ -41,7 +43,7 @@ export const useJariDetailData = (name: string | undefined) => {
   }, [name]);
 
   useEffect(() => {
-    if (!name) return;
+    if (!name || !allMaps) return;
 
     const fetchMapData = async () => {
       setLoadingMeta(true);
@@ -49,9 +51,8 @@ export const useJariDetailData = (name: string | undefined) => {
       setLoadingPriceStat(true);
 
       try {
-        const metaDataList = await fetchAutocomplete(name);
         const decodedName = decodeURIComponent(name).replace(/\s/g, "");
-        const matched = metaDataList.find(
+        const matched = allMaps.find(
           (m) => m.mapName.replace(/\s/g, "") === decodedName
         );
 
@@ -75,7 +76,7 @@ export const useJariDetailData = (name: string | undefined) => {
     };
 
     fetchMapData();
-  }, [name, loadLazyData]);
+  }, [name, allMaps, loadLazyData]);
 
   return {
     mapMeta,

--- a/frontend/src/page/jari/Detail.tsx
+++ b/frontend/src/page/jari/Detail.tsx
@@ -28,7 +28,7 @@ const JariDetailPage = () => {
 
   const { data: jari, refetch } = useJariList(name ?? "");
 
-  const mapId = mapMeta?.mapleLandMapListId;
+  const mapId = mapMeta?.mapId;
   const mapName = mapMeta?.mapName.split(":")[1] ?? "";
 
   const { isAlarmOn, toggleAlarm } = useAlertStatus(mapId, mapName);


### PR DESCRIPTION
## 📝 개요
기존에 맵 이름 검색 시 사용되던 `fetchAutocomplete` 호출을 제거하고,
전역 상태에 보관된 전체 맵 목록(`allMaps`)에서 직접 검색하도록 변경했습니다.

## ✨ 변경 사항
- `fetchAutocomplete` API 제거
- useEffect 내부 로직에서 allMaps로 대체
- 불필요한 네트워크 요청 제거로 UX 개선 및 성능 향상 기대

## 📌 참고 사항
- 백엔드 `GET /api/maps/autocomplete` API는 추후 제거 가능
- allMaps는 초기 앱 로딩 시 1회 fetch 후 캐싱되는 구조로 유지

## 🔗 관련 이슈
Closes #147 
