### PR TITLE
style: profile-page 프로필칸 크기 조절

### DIFF
--- a/frontend/src/feature/trade/hooks/useJariDetailData.ts
+++ b/frontend/src/feature/trade/hooks/useJariDetailData.ts
@@ -29,9 +29,9 @@ export const useJariDetailData = (name: string | undefined) => {
 
       if (!res.ok) throw new Error("맵 상세 데이터 요청 실패");
 
-      const json = await res.json();
+      const data = await res.json();
 
-      const { dropItemResponse, priceStatDtoList } = json;
+      const { dropItemResponse, priceStatDtoList } = data;
 
       setDropItems(dropItemResponse ?? []);
       setPriceStats(priceStatDtoList ?? []);

--- a/frontend/src/page/Profile.tsx
+++ b/frontend/src/page/Profile.tsx
@@ -46,16 +46,16 @@ const ProfilePage = () => {
   );
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 h-full">
+    <div className="grid grid-cols-1 lg:grid-cols-8 gap-4 h-full">
       {/* 왼쪽: 프로필 정보 */}
-      <div className="col-span-5 lg:col-span-1 lg:sticky top-24 self-start">
+      <div className="col-span-8 lg:col-span-2 lg:sticky top-24 self-start">
         <UserProfileCard
           userInfo={userInfo}
           isMyProfile={isMyProfile}
           refetch={refetch}
         />
       </div>
-      <div className="col-span-5 lg:col-span-4 gap-6">
+      <div className="col-span-8 lg:col-span-6">
         {isMyProfile && (
           <AlertMapSection isMyProfile={isMyProfile} alertMaps={alertMaps} />
         )}{" "}


### PR DESCRIPTION
## 📝 개요
ProfilePage 컴포넌트의 전체 그리드 컬럼을 기존 5에서 8로 확장하여 
좌/우 영역 비율을 더 유연하게 조절할 수 있도록 수정했습니다.

## ✨ 변경 사항
- `grid-cols-5` → `grid-cols-8`
- 프로필 카드: `col-span-2`
- 거래 섹션: `col-span-6`
- 모바일 및 태블릿 구간은 기존처럼 `grid-cols-1` 유지

## 💡 이유
- 기존 레이아웃에서 거래 카드들이 너무 좁게 표시됨
- col-8으로 늘려 좌측 고정 + 우측 콘텐츠에 더 많은 공간 확보

