### PR TITLE
feat: 실시간 거래 현황 SSE 구현

### DIFF
--- a/backend/src/main/java/org/mapleland/maplelanbackserver/config/SecurityConfiguration.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/config/SecurityConfiguration.java
@@ -61,7 +61,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/manager/**").hasAnyRole("MANAGER", "ADMIN")
                         .requestMatchers("/api/jari/**", "/api/alert/**","/api/reports/**").hasAnyRole("USER", "MANAGER", "ADMIN")
-                        .requestMatchers("/api/**","/ws/**").permitAll()
+                        .requestMatchers("/api/**","/ws/**", "/sse/**").permitAll()
                 ).exceptionHandling(exception -> {
                     exception.authenticationEntryPoint((request, response, authException) -> {
                         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/controller/SseController.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/controller/SseController.java
@@ -1,0 +1,18 @@
+package org.mapleland.maplelanbackserver.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.mapleland.maplelanbackserver.service.JariSseBroadCaster;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RequiredArgsConstructor
+@RestController
+public class SseController {
+    private final JariSseBroadCaster broadCaster;
+
+    @GetMapping("/sse/jari")
+    public SseEmitter subscribeJariStream() {
+        return broadCaster.subscribe();
+    }
+}

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/dto/jari/JariCompletedEvent.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/dto/jari/JariCompletedEvent.java
@@ -1,0 +1,34 @@
+package org.mapleland.maplelanbackserver.dto.jari;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.mapleland.maplelanbackserver.enumType.TradeType;
+import org.mapleland.maplelanbackserver.table.Jari;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class JariCompletedEvent {
+    private int jariId;
+    private String mapName;
+    private String globalName;
+    private TradeType tradeType;
+    private int price;
+    private boolean isCompleted;
+    private LocalDateTime completedTime;
+
+    public static JariCompletedEvent from(Jari jari, String globalName) {
+        return new JariCompletedEvent(
+                jari.getUserMapId(),
+                jari.getMapName(),
+                globalName,
+                jari.getTradeType(),
+                jari.getPrice(),
+                jari.getIsCompleted(),
+                jari.getUpdateTime()
+        );
+    }
+}

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/service/JariSseBroadCaster.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/service/JariSseBroadCaster.java
@@ -1,0 +1,36 @@
+package org.mapleland.maplelanbackserver.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class JariSseBroadCaster {
+    private final Set<SseEmitter> emitters = ConcurrentHashMap.newKeySet();
+
+    public SseEmitter subscribe() {
+        SseEmitter emitter = new SseEmitter(60 * 60 * 1000L); // 1시간
+
+        emitters.add(emitter);
+        emitter.onCompletion(() -> emitters.remove(emitter));
+        emitter.onTimeout(() -> emitters.remove(emitter));
+        emitter.onError((e) -> {
+            emitter.completeWithError(e);
+            emitters.remove(emitter);
+        });
+        return emitter;
+    }
+
+    // 거래 알림 전송
+    public void broadcast(Object event) {
+        emitters.forEach(emitter -> {
+            try {
+                emitter.send(SseEmitter.event().name("jari-complete").data(event));
+            } catch (Exception e) {
+                emitters.remove(emitter);
+            }
+        });
+    }
+}

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.mapleland.maplelanbackserver.dto.Map.*;
+import org.mapleland.maplelanbackserver.dto.jari.JariCompletedEvent;
 import org.mapleland.maplelanbackserver.dto.response.DropItemResponse;
 import org.mapleland.maplelanbackserver.dto.request.JariUpdateRequest;
 import org.mapleland.maplelanbackserver.dto.request.JariIsCompletedRequest;
@@ -55,6 +56,7 @@ public class MapService {
     private final MapInterRestRepository interestRepository;
     private final UtilMethod utilMethod;
     private final WebSocketService webSocketService;
+    private final JariSseBroadCaster broadCaster;
 
     String message;
     @Value("${frontend.redirect-url}")
@@ -442,6 +444,7 @@ public class MapService {
         jariRepository.save(jari);
         userRepository.save(user);
 
+        broadCaster.broadcast(JariCompletedEvent.from(jari, user.getGlobalName()));
     }
 
 //    public MapNameListResponse findAllMaps() {


### PR DESCRIPTION
## 📝 개요
실시간 거래 현황을 보여주기 위해 SSE 를 활용하여 구현하였습니다.

## ✨ 상세 내용
* 클라이언트는 `/sse/jari` 엔드포인트를 통해 SSE 스트림에 접속하여 실시간 거래 현황 이벤트를 수신합니다.
* 이벤트 데이터는 자리 ID, 맵 이름, 가격, 거래 유형, 거래자 닉네임, 완료 시간 등의 정보를 포함합니다.

## 📌 기타
* SSE 연결 유지 및 에러 처리에 대한 주의가 필요하며, 서버 리소스 대비 동시 구독자 수를 모니터링해야 합니다.
* 서버 단에서는 구독 관리, 이벤트 브로드캐스트 시 Exception 처리를 통해 안정성을 확보하고, 필요 시 별도의 비동기 처리 및 큐잉 시스템 도입을 고려할 수 있습니다.

## 🔗 관련 이슈
This closes #172 
