### PR TITLE
fix: 관리자가 거래글을 삭제해도 티켓을 돌려주도록 수정

### DIFF
--- a/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
@@ -18,6 +18,7 @@ import org.mapleland.maplelanbackserver.enumType.alert.AlertStatus;
 import org.mapleland.maplelanbackserver.exception.coflict.ConflictException;
 import org.mapleland.maplelanbackserver.exception.coflict.CoolDownConflictException;
 import org.mapleland.maplelanbackserver.exception.notfound.NotFoundException;
+import org.mapleland.maplelanbackserver.exception.notfound.jari.JariNotFoundException;
 import org.mapleland.maplelanbackserver.exception.notfound.jari.NotFoundMapException;
 import org.mapleland.maplelanbackserver.exception.notfound.jari.NotFoundMapTicketException;
 import org.mapleland.maplelanbackserver.exception.notfound.jari.NotFoundUserException;
@@ -390,22 +391,15 @@ public class MapService {
     }
 
     public void mapDelete(int mapId, String token) {
+        Jari jari = jariRepository.findByUserMapId(mapId);
+        if (jari == null) {
+            throw new JariNotFoundException();
+        }
 
-
-        Jari byUserId = jariRepository.findByUserMapId(mapId);
         int userId = JwtUtil.getUserId(token);
 
-        if (byUserId.getUser().getUserId() == userId || JwtUtil.getRole(token).equals("ROLE_ADMIN")) {
+        if (jari.getUser().getUserId() == userId || JwtUtil.getRole(token).equals("ROLE_ADMIN")) {
             User user = userRepository.findByUserId(userId).orElseThrow(() -> new NotFoundUserException("사용자를 찾을 수 없음"));
-
-            String role = JwtUtil.getRole(token);
-
-            Jari jari = null;
-
-            if (role.equals("ROLE_USER")) {
-                jari = jariRepository.findByUser_UserIdAndUserMapId(userId, mapId).
-                        orElseThrow(() -> new NotFoundException("알 수 없는 에러가 발생 하였습니다."));
-            }
 
             TradeType tradeType = jari.getTradeType();
             switch (tradeType) {
@@ -414,7 +408,7 @@ public class MapService {
             }
 
             userRepository.save(user);
-            jariRepository.delete(byUserId);
+            jariRepository.delete(jari);
         } else throw new UserMismatchException("등록된 게시글과 다른 사용자 입니다.");
     }
 

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
@@ -389,42 +389,42 @@ public class MapService {
         jariRepository.save(byUserId);
     }
 
-    public void mapDelete(int mapId,String token) {
+    public void mapDelete(int mapId, String token) {
 
 
         Jari byUserId = jariRepository.findByUserMapId(mapId);
         int userId = JwtUtil.getUserId(token);
 
-        if(byUserId.getUser().getUserId() == userId || JwtUtil.getRole(token).equals("ROLE_ADMIN")) {
+        if (byUserId.getUser().getUserId() == userId || JwtUtil.getRole(token).equals("ROLE_ADMIN")) {
             User user = userRepository.findByUserId(userId).orElseThrow(() -> new NotFoundUserException("사용자를 찾을 수 없음"));
 
             String role = JwtUtil.getRole(token);
 
-            if(role.equals("ROLE_USER")) {
+            Jari jari = null;
 
-                Jari jari = jariRepository.findByUser_UserIdAndUserMapId(userId, mapId).
+            if (role.equals("ROLE_USER")) {
+                jari = jariRepository.findByUser_UserIdAndUserMapId(userId, mapId).
                         orElseThrow(() -> new NotFoundException("알 수 없는 에러가 발생 하였습니다."));
-
-                TradeType tradeType = jari.getTradeType();
-
-                switch (tradeType) {
-                    case BUY -> user.setBuyTicket(true);
-                    case SELL -> user.setSellTicket(true);
-                }
             }
+
+            TradeType tradeType = jari.getTradeType();
+            switch (tradeType) {
+                case BUY -> user.setBuyTicket(true);
+                case SELL -> user.setSellTicket(true);
+            }
+
             userRepository.save(user);
             jariRepository.delete(byUserId);
-        }
-        else throw new UserMismatchException("등록된 게시글과 다른 사용자 입니다.");
+        } else throw new UserMismatchException("등록된 게시글과 다른 사용자 입니다.");
     }
 
-    public void updateIsCompleted(JariIsCompletedRequest dto , String token) {
+    public void updateIsCompleted(JariIsCompletedRequest dto, String token) {
         int userId = JwtUtil.getUserId(token);
         Jari jari = jariRepository.findByUserMapId(dto.mapId());
-        if(jari == null) throw new NotFoundMapException("게시글을 찾을 수 없습니다.");
+        if (jari == null) throw new NotFoundMapException("게시글을 찾을 수 없습니다.");
 
 
-        if(jari.getUser().getUserId() != userId) throw new UserMismatchException("사용자가 다릅니다.");
+        if (jari.getUser().getUserId() != userId) throw new UserMismatchException("사용자가 다릅니다.");
 
         User user = userRepository.findByUserId(userId).
                 orElseThrow(() -> new NotFoundUserException("사용자를 찾을 수 없습니다."));


### PR DESCRIPTION
## 📝 개요
관리자가 거래글을 삭제하는 경우, 해당 거래글의 작성자에게 티켓(작성권한)이 안돌아가서,
거래글 작성을 하지 못하는 문제가 발생했었습니다.

이를 수정합니다.

## 🔗 관련 이슈
This closes #175 
