### PR TITLE
기존 /sse/jari SSE 방식이 제대로 작동하지 않아, 거래 완료 시 메인 페이지에 최신 거래 글이 즉시 반영되지 않는 문제를 해결했습니다.

### DIFF
--- a/frontend/src/entity/trade/store/useRecentTradeStore.ts
+++ b/frontend/src/entity/trade/store/useRecentTradeStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+export interface Trade {
+  mapName: string;
+  price: number;
+  tradeType: "SELL" | "BUY";
+}
+
+interface RecentTradeStore {
+  recentTrade: Trade | null;
+  setRecentTrade: (trade: Trade) => void;
+}
+
+export const useRecentTradeStore = create<RecentTradeStore>((set) => ({
+  recentTrade: null,
+  setRecentTrade: (trade) => set({ recentTrade: trade }),
+}));

--- a/frontend/src/feature/jari/ui/EditJariPopover.tsx
+++ b/frontend/src/feature/jari/ui/EditJariPopover.tsx
@@ -1,7 +1,7 @@
 import * as Popover from "@radix-ui/react-popover";
 import { Button } from "@/shared/ui/button/Button";
 import { ServerColor } from "../../trade/ui/TradeCard";
-
+import { useRecentTradeStore } from "@/entity/trade/store/useRecentTradeStore";
 interface Props {
   editServerColor: ServerColor;
   editPrice: number;
@@ -17,6 +17,8 @@ interface Props {
   showEditBox: boolean;
   setShowEditBox: (open: boolean) => void;
   handleBump: () => void;
+  tradeType: "SELL" | "BUY";
+  mapName: string;
 }
 
 export const EditJariPopover = ({
@@ -34,7 +36,10 @@ export const EditJariPopover = ({
   showEditBox,
   setShowEditBox,
   handleBump,
+  tradeType,
+  mapName,
 }: Props) => {
+  const { setRecentTrade } = useRecentTradeStore();
   return (
     <div className="relative flex items-center">
       <Popover.Root open={showEditBox} onOpenChange={setShowEditBox}>
@@ -123,7 +128,7 @@ export const EditJariPopover = ({
               />
             </div>
 
-            {/* 거래 완료, 삭제 버튼 */}
+            {/* 범프, 거래 완료, 삭제 버튼 */}
             <Button
               variant="outline"
               type="button"
@@ -136,7 +141,14 @@ export const EditJariPopover = ({
               variant="blue"
               type="button"
               className="px-3 py-1 text-xs text-white rounded-sm transition h-auto"
-              onClick={handleMarkAsCompleted}
+              onClick={() => {
+                handleMarkAsCompleted();
+                setRecentTrade({
+                  mapName: mapName,
+                  price: editPrice,
+                  tradeType: tradeType,
+                });
+              }}
             >
               거래 완료
             </Button>

--- a/frontend/src/feature/trade/hooks/useCompletedTrades.ts
+++ b/frontend/src/feature/trade/hooks/useCompletedTrades.ts
@@ -1,34 +1,6 @@
-import { useEffect, useState } from "react";
-import { API_BASE_URL } from "@/shared/config/api";
-
-export interface CompletedTrade {
-  jariId: number;
-  mapName: string;
-  globalName: string;
-  tradeType: "SELL" | "BUY";
-  price: number;
-  completedTime: string;
-  completed: boolean;
-}
+import { useRecentTradeStore } from "@/entity/trade/store/useRecentTradeStore";
 
 export const useLatestCompletedTrade = () => {
-  const [trade, setTrade] = useState<CompletedTrade | null>(null);
-
-  useEffect(() => {
-    const eventSource = new EventSource(`${API_BASE_URL}/sse/jari`);
-
-    const handleCompleted = (e: MessageEvent) => {
-      const data: CompletedTrade = JSON.parse(e.data);
-      setTrade(data); // 항상 마지막 거래 하나만 유지
-    };
-
-    eventSource.addEventListener("jari-complete", handleCompleted);
-
-    return () => {
-      eventSource.removeEventListener("jari-complete", handleCompleted);
-      eventSource.close();
-    };
-  }, []);
-
+  const trade = useRecentTradeStore((s) => s.recentTrade);
   return trade;
 };

--- a/frontend/src/feature/trade/ui/CompletedTradeBox.tsx
+++ b/frontend/src/feature/trade/ui/CompletedTradeBox.tsx
@@ -4,13 +4,13 @@ import { useLatestCompletedTrade } from "../hooks/useCompletedTrades";
 
 export const CompletedTradeBox = () => {
   const trade = useLatestCompletedTrade();
-
+  console.log(trade);
   return (
     <div className="">
       <AnimatePresence mode="wait">
         {trade && (
           <motion.div
-            key={trade.jariId}
+            key={trade.mapName}
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 10 }}

--- a/frontend/src/feature/trade/ui/TradeCard.tsx
+++ b/frontend/src/feature/trade/ui/TradeCard.tsx
@@ -79,6 +79,8 @@ const TradeCard = ({ item, refetch, showEditButton }: Props) => {
               handleDelete={handleDelete}
               handleUpdate={handleUpdate}
               handleBump={handleBump}
+              tradeType={item.tradeType}
+              mapName={item.mapName}
             />
           )}
           <div className="flex-1 flex justify-between items-center">


### PR DESCRIPTION
## 📝 개요
기존 /sse/jari SSE 방식이 제대로 작동하지 않아,
거래 완료 시 메인 페이지에 최신 거래 글이 즉시 반영되지 않는 문제를 해결했습니다.
SSE 대신 프론트 상태를 직접 갱신하는 방식으로 수정했습니다.

## ✨ 상세 내용
handleMarkAsCompleted() 함수 내에서 거래 완료 처리 후
useLatestCompletedTradeStore().setTrade()를 호출하여
최근 거래 상태를 클라이언트에서 직접 반영하도록 구현

CompletedTradeBox는 해당 상태를 구독하고 있어
별도의 API 호출 없이도 거래 완료 후 즉시 UI에 반영됩니다.

기존 SSE 방식은 유지하지 않으며, 프론트 상태 갱신만으로 해결

## 📌 기타
참고해야 할 사항, 스크린샷, 논의점 등

## 🔗 관련 이슈
close #182 
