### PR TITLE
feat: 모든 맵 정보 조회 캐시 갱신 API 구현

### DIFF
--- a/backend/src/main/java/org/mapleland/maplelanbackserver/controller/admincontroller/AdminController.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/controller/admincontroller/AdminController.java
@@ -3,13 +3,11 @@ package org.mapleland.maplelanbackserver.controller.admincontroller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.mapleland.maplelanbackserver.dto.BanUserRequest;
+import org.mapleland.maplelanbackserver.dto.Map.MapInfoListResponse;
 import org.mapleland.maplelanbackserver.dto.report.ReportedPostWithReasonsDto;
 import org.mapleland.maplelanbackserver.dto.response.*;
 import org.mapleland.maplelanbackserver.dto.user.UserResponse;
-import org.mapleland.maplelanbackserver.service.MapService;
-import org.mapleland.maplelanbackserver.service.ReportService;
-import org.mapleland.maplelanbackserver.service.UserService;
-import org.mapleland.maplelanbackserver.service.WebSocketService;
+import org.mapleland.maplelanbackserver.service.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -28,6 +26,7 @@ public class AdminController {
     private final ReportService reportService;
     private final UserService userService;
     private final MapService mapService;
+    private final MapCacheService mapCacheService;
 
     @GetMapping("/api/admin/users")
     public ResponseEntity<List<UserListResponse>> findAllUsersOrderByReportCount(@RequestParam(defaultValue = "0") int page) {
@@ -98,4 +97,10 @@ public class AdminController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "맵 캐시 강제 갱신")
+    @PostMapping("/api/admin/maps/all/refresh")
+    public ResponseEntity<MapInfoListResponse> refreshMapsCache() {
+        MapInfoListResponse response = mapCacheService.putAllMapsCache();
+        return ResponseEntity.ok(response);
+    }
 }

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapCacheService.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapCacheService.java
@@ -2,6 +2,7 @@ package org.mapleland.maplelanbackserver.service;
 
 import lombok.RequiredArgsConstructor;
 import org.mapleland.maplelanbackserver.dto.Map.MapInfoListResponse;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -13,6 +14,11 @@ public class MapCacheService {
 
     @Cacheable(value = "all_maps", cacheManager = "localCacheManger")
     public MapInfoListResponse findAllMapsCache() {
+        return mapService.findAllMaps();
+    }
+
+    @CachePut(value = "all_maps", cacheManager = "localCacheManger")
+    public MapInfoListResponse putAllMapsCache() {
         return mapService.findAllMaps();
     }
 }


### PR DESCRIPTION
## 📝 개요
현재 DB에 맵 정보가 업데이트되어도 캐싱때문에 조회되지 않는 문제가 있습니다.
이에 캐시 갱신 API 를 따로 구현하였습니다.

## ✨ 상세 내용
`@CachePut` annotation 을 사용하여 간단하게 구현하였습니다.

## 🔗 관련 이슈
This closes #186 
