### PR TITLE
맵 이름에 상세 페이지 링크 추가 및 hover 효과 적용

### DIFF
--- a/frontend/src/feature/trade/ui/TradeCardHeader.tsx
+++ b/frontend/src/feature/trade/ui/TradeCardHeader.tsx
@@ -57,7 +57,13 @@ export const TradeCardHeader = ({
       <div className="flex flex-col w-full relative">
         <div className="flex justify-between items-center pb-1 border-b border-neutral-700">
           <p className="text-xs lg:text-base font-bold">
-            {mapName.includes(":") ? mapName.split(":")[1].trim() : mapName}
+            <Link
+              to={`/jari/${mapName}`}
+              title={`${mapName} 자리 페이지로 이동`}
+              className="hover:underline"
+            >
+              {mapName.includes(":") ? mapName.split(":")[1].trim() : mapName}
+            </Link>
           </p>
           <Link
             to={`/profile/${userId}`}


### PR DESCRIPTION
## ✨ 변경 사항  
- TradeCardHeader 컴포넌트에서 맵 이름에 상세 페이지(`/jari/:mapName`)로 이동할 수 있도록 Link 컴포넌트로 감쌌습니다.
- 기존 몬스터 이미지에도 링크가 있기 때문에 UI 혼동이 없도록 구조를 유지했습니다.



## 🔗 관련 이슈  
- close #206 