### PR TITLE
feat: completedtrade를 누르면 거래완료글에 focus가는 기능 추가

### DIFF
--- a/frontend/src/app/router/router.tsx
+++ b/frontend/src/app/router/router.tsx
@@ -28,6 +28,7 @@ const AllUsersPage = lazy(() => import("@/page/admin/AllUsers"));
 const UserStatsPage = lazy(() => import("@/page/admin/UserStatsPage"));
 const ReportPage = lazy(() => import("@/page/admin/Report"));
 const ReportDetailPage = lazy(() => import("@/page/admin/ReportDetail"));
+const NoticeWritePage = lazy(() => import("@/page/admin/NoticeWrite"));
 
 const router = createBrowserRouter([
   {
@@ -106,6 +107,14 @@ const router = createBrowserRouter([
             element: (
               <RequireAdmin>
                 <ReportPage />
+              </RequireAdmin>
+            ),
+          },
+          {
+            path: "notice/new",
+            element: (
+              <RequireAdmin>
+                <NoticeWritePage />
               </RequireAdmin>
             ),
           },

--- a/frontend/src/feature/trade/ui/CompletedTradeBox.tsx
+++ b/frontend/src/feature/trade/ui/CompletedTradeBox.tsx
@@ -34,7 +34,9 @@ export const CompletedTradeBox = () => {
           className="absolute w-full"
         >
           <Link
-            to={`/jari/${encodeURIComponent(trade.mapName)}`}
+            to={`/jari/${encodeURIComponent(trade.mapName)}?focus=${
+              trade.userMapId
+            }`}
             className="flex justify-between items-center bg-gradient-to-r from-neutral-700 to-neutral-800 border border-green-500 text-green-300 px-4 py-3 rounded-lg text-sm font-medium shadow-sm gap-2 w-full cursor-pointer hover:from-neutral-600 hover:to-neutral-700 transition-colors"
           >
             <div className="flex items-center gap-2 overflow-hidden flex-1 min-w-0">

--- a/frontend/src/feature/trade/ui/TradeCard.tsx
+++ b/frontend/src/feature/trade/ui/TradeCard.tsx
@@ -39,8 +39,9 @@ const TradeCard = ({ item, refetch, showEditButton }: Props) => {
 
   return (
     <div
+      id={`trade-${item.userMapId}`}
       className={clsx(
-        "bg-neutral-800 text-white  py-4 px-4 flex flex-col gap-3 items-start shadow transition duration-300",
+        "bg-neutral-800 text-white  py-4 px-4 flex flex-col gap-3 items-start shadow transition duration-300 rounded-sm",
         {
           "opacity-40 grayscale": item.isCompleted,
         }

--- a/frontend/src/page/admin/Dashboard.tsx
+++ b/frontend/src/page/admin/Dashboard.tsx
@@ -48,6 +48,7 @@ const DashboardPage = () => {
         <SummaryCard title="총 회원" to="/admin/users" sumUsers={sumUsers} />
         <SummaryCard title="월간 가입자 통계" to="/admin/signupcount" />
         <SummaryCard title="신고된 게시글" to="/admin/reports" />
+        <SummaryCard title="공지사항 쓰기" to="/admin/notice/new" />
       </div>
 
       {/* 자리 목록 */}

--- a/frontend/src/page/admin/NoticeWrite.tsx
+++ b/frontend/src/page/admin/NoticeWrite.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import { Input } from "@/shared/ui/input/Input";
+
+const NoticeWritePage = () => {
+  const [title, setTitle] = useState("");
+  const [markdown, setMarkdown] = useState("");
+
+  const handleSubmit = async () => {
+    await fetch("/api/notices", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title, content: markdown }),
+    });
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-4">
+      <Input
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="공지 제목"
+      />
+      <textarea
+        value={markdown}
+        onChange={(e) => setMarkdown(e.target.value)}
+        rows={12}
+        className="w-full border p-3 rounded bg-neutral-900 text-white"
+        placeholder="공지 내용을 마크다운으로 작성하세요"
+      />
+      <h3 className="text-lg font-bold mt-4">🖼️ 미리보기</h3>
+      <div className="p-4 border rounded bg-neutral-800 text-white prose prose-invert max-w-none">
+        <ReactMarkdown>{markdown}</ReactMarkdown>
+      </div>
+
+      <button
+        onClick={handleSubmit}
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+      >
+        공지 작성하기
+      </button>
+    </div>
+  );
+};
+export default NoticeWritePage;

--- a/frontend/src/page/jari/Detail.tsx
+++ b/frontend/src/page/jari/Detail.tsx
@@ -1,5 +1,5 @@
-import { useParams, Navigate } from "react-router-dom";
-import { lazy, Suspense } from "react";
+import { useParams, Navigate, useSearchParams } from "react-router-dom";
+import { lazy, useEffect } from "react";
 import { JariItem } from "@/entity/jari/model/type";
 import { Spinner } from "@/shared/ui/spinner/Spinner";
 import { useJariList } from "@/feature/trade/hooks/useJariList";
@@ -15,7 +15,8 @@ const DropItemSection = lazy(() => import("@/feature/jari/ui/DropItemSection"));
 
 const JariDetailPage = () => {
   const { name } = useParams();
-
+  const [searchParams] = useSearchParams();
+  const focusId = searchParams.get("focus");
   const {
     mapMeta,
     dropItems,
@@ -34,6 +35,54 @@ const JariDetailPage = () => {
     jari?.filter((item: JariItem) => item.tradeType === "BUY") ?? [];
   const sellJari =
     jari?.filter((item: JariItem) => item.tradeType === "SELL") ?? [];
+  useEffect(() => {
+    if (!focusId) return;
+
+    const targetId = `trade-${focusId}`;
+
+    const tryScroll = () => {
+      const el = document.getElementById(targetId);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        el.classList.add(
+          "ring",
+          "ring-4",
+          "ring-pink-500", // 더 강한 색상 (눈에 확 띔)
+          "ring-offset-2",
+          "ring-offset-neutral-800", // 배경 어두운 톤과 어울림
+          "bg-pink-500/20", // 배경 강조도 더 진하게
+          "scale-105",
+          "transition",
+          "duration-500",
+          "rounded-sm"
+        );
+        setTimeout(() => {
+          el.classList.remove(
+            "ring",
+            "ring-4",
+            "ring-pink-500",
+            "ring-offset-2",
+            "ring-offset-neutral-800",
+            "bg-pink-500/20",
+            "scale-105",
+            "rounded-sm"
+          );
+        }, 3000);
+        return true;
+      }
+      return false;
+    };
+
+    if (tryScroll()) return;
+
+    const observer = new MutationObserver(() => {
+      if (tryScroll()) observer.disconnect();
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, [focusId]);
 
   if (errorMessage) {
     return <Navigate to="/404" replace />;
@@ -64,23 +113,13 @@ const JariDetailPage = () => {
 
       {/* 오른쪽: 드랍 아이템 + 거래 목록 */}
       <div className="col-span-8 lg:col-span-6 flex flex-col gap-6">
-        <Suspense fallback={<p className="text-white">드랍 정보 로딩 중...</p>}>
-          <DropItemSection dropItems={dropItems} />
-        </Suspense>
+        <DropItemSection dropItems={dropItems} />
 
-        <Suspense
-          fallback={
-            <div className="text-white text-center col-span-2">
-              거래 목록 로딩 중...
-            </div>
-          }
-        >
-          <TradeSections
-            sellJari={sellJari}
-            buyJari={buyJari}
-            refetch={refetch}
-          />
-        </Suspense>
+        <TradeSections
+          sellJari={sellJari}
+          buyJari={buyJari}
+          refetch={refetch}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## 📝 개요
거래 목록에서 특정 거래글을 강조할 수 있도록 개선

## ✨ 상세 내용
거래글 상세 페이지에서 ?focus=ID 파라미터 처리

해당 거래글로 부드럽게 스크롤 이동

ring, scale, bg 등을 활용한 강조 UI

거래 완료된 항목은 회색 처리 유지
## 📌 기타
참고해야 할 사항, 스크린샷, 논의점 등

## 🔗 관련 이슈
-close #208 
