### PR TITLE
refactor: AdminUserPage 검색바/리스트/카드 컴포넌트로 분리

### DIFF
--- a/frontend/src/feature/admin/ui/UserCard.tsx
+++ b/frontend/src/feature/admin/ui/UserCard.tsx
@@ -1,0 +1,39 @@
+import { AdminUsersInfo } from "@/entity/user/model/type";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/shared/ui/button/Button";
+import { convertToKoreaTime } from "@/shared/utils/date";
+
+interface UserCardProps {
+  user: AdminUsersInfo;
+}
+
+export const UserCard = ({ user }: UserCardProps) => {
+  const navigate = useNavigate();
+  const koreaTime = convertToKoreaTime(user.createTime);
+
+  return (
+    <li className="bg-neutral-800 text-white rounded-lg p-4 shadow hover:ring-2 hover:ring-blue-400 transition">
+      <p className="text-lg font-semibold mb-1">{user.globalName}</p>
+      <p className="text-sm text-neutral-400">{user.userName}</p>
+      <p className="text-sm text-neutral-400">ID: {user.userId}</p>
+      <p className="text-sm text-neutral-400">Discord: {user.discordId}</p>
+      <p className="text-sm text-neutral-400">
+        역할: {user.role?.replace("ROLE_", "")}
+      </p>
+      <p className="text-sm text-neutral-400">
+        신고당한 횟수: {user.reportedCount}
+      </p>
+      <p className="text-sm text-neutral-500 mt-1">
+        가입일: {koreaTime.toLocaleString("ko-KR")}
+      </p>
+      <div className="flex justify-end">
+        <Button
+          onClick={() => navigate(`/profile/${user.userId}`)}
+          className="px-2 py-1 h-6 text-xs bg-blue-500 hover:bg-blue-600 rounded text-white"
+        >
+          프로필 보기
+        </Button>
+      </div>
+    </li>
+  );
+};

--- a/frontend/src/feature/admin/ui/UserListSection.tsx
+++ b/frontend/src/feature/admin/ui/UserListSection.tsx
@@ -1,0 +1,75 @@
+import { BannedUserInfo, AdminUsersInfo } from "@/entity/user/model/type";
+import { Button } from "@/shared/ui/button/Button";
+import BannedUserCard from "@/feature/ban/ui/UserBannedCard";
+import { UserCard } from "./UserCard";
+
+interface UserListSectionProps {
+  searchResult: AdminUsersInfo[] | null;
+  searchLoading: boolean;
+  searchError: string;
+  usersToRender: AdminUsersInfo[];
+  loading: boolean;
+  showBannedOnly: boolean;
+  toggleBannedFilter: () => void;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+}
+
+export const UserListSection = ({
+  searchResult,
+  searchLoading,
+  searchError,
+  usersToRender,
+  loading,
+  showBannedOnly,
+  toggleBannedFilter,
+  setPage,
+}: UserListSectionProps) => {
+  if (searchLoading) return <p>검색 중...</p>;
+  if (searchError) return <p className="text-red-500">{searchError}</p>;
+
+  if (searchResult) {
+    return (
+      <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {searchResult.length === 0 ? (
+          <li className="text-white">검색 결과가 없습니다.</li>
+        ) : (
+          searchResult.map((user) => <UserCard key={user.userId} user={user} />)
+        )}
+      </ul>
+    );
+  }
+
+  return (
+    <>
+      <Button
+        className="mb-4 bg-red-600 hover:bg-red-700 text-white text-sm px-3 py-1 rounded"
+        onClick={toggleBannedFilter}
+      >
+        {showBannedOnly ? "전체 사용자 보기" : "밴된 사용자만 보기"}
+      </Button>
+
+      {loading ? (
+        <p>로딩 중...</p>
+      ) : (
+        <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {usersToRender.map((user) =>
+            showBannedOnly ? (
+              <BannedUserCard key={user.userId} user={user as BannedUserInfo} />
+            ) : (
+              <UserCard key={user.userId} user={user} />
+            )
+          )}
+        </ul>
+      )}
+
+      {!showBannedOnly && (
+        <div className="mt-4 space-x-2">
+          <button onClick={() => setPage((p) => Math.max(p - 1, 0))}>
+            이전
+          </button>
+          <button onClick={() => setPage((p) => p + 1)}>다음</button>
+        </div>
+      )}
+    </>
+  );
+};

--- a/frontend/src/feature/admin/ui/UserSearchBar.tsx
+++ b/frontend/src/feature/admin/ui/UserSearchBar.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/shared/ui/button/Button";
+
+interface AdminUserSearchBarProps {
+  search: string;
+  onChange: (value: string) => void;
+  onSearch: () => void;
+  onClear: () => void;
+}
+
+export const AdminUserSearchBar = ({
+  search,
+  onChange,
+  onSearch,
+  onClear,
+}: AdminUserSearchBarProps) => {
+  return (
+    <div className="flex items-center gap-2 mb-4">
+      <input
+        type="text"
+        placeholder="GlobalName으로 검색"
+        value={search}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && onSearch()}
+        className="px-2 py-1 border rounded text-black"
+      />
+      <Button
+        onClick={onSearch}
+        className="bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 text-xs"
+      >
+        검색
+      </Button>
+      {search && (
+        <Button
+          onClick={onClear}
+          className="bg-gray-400 hover:bg-gray-500 text-white px-2 py-1 text-xs"
+        >
+          초기화
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/page/admin/AllUsers.tsx
+++ b/frontend/src/page/admin/AllUsers.tsx
@@ -1,11 +1,10 @@
-import { BannedUserInfo, AdminUsersInfo } from "@/entity/user/model/type";
-import { useNavigate } from "react-router-dom";
-import { Button } from "@/shared/ui/button/Button";
-import BannedUserCard from "@/feature/ban/ui/UserBannedCard";
-import { useAdminUsers } from "@/feature/admin/ui/hooks/useAdminUsers";
 import { useState } from "react";
+import { useAdminUsers } from "@/feature/admin/ui/hooks/useAdminUsers";
 import { getUserByGlobalName } from "@/entity/user/api/getUserByGlobalName";
-import { convertToKoreaTime } from "@/shared/utils/date";
+import { AdminUsersInfo } from "@/entity/user/model/type";
+
+import { AdminUserSearchBar } from "@/feature/admin/ui/UserSearchBar";
+import { UserListSection } from "@/feature/admin/ui/UserListSection";
 
 const AdminUserPage = () => {
   const {
@@ -16,8 +15,6 @@ const AdminUserPage = () => {
     setPage,
     loading,
   } = useAdminUsers();
-
-  const navigate = useNavigate();
 
   const [search, setSearch] = useState("");
   const [searchResult, setSearchResult] = useState<AdminUsersInfo[] | null>(
@@ -35,11 +32,7 @@ const AdminUserPage = () => {
       setSearchResult(result as AdminUsersInfo[]);
     } catch (err: unknown) {
       setSearchResult(null);
-      if (err instanceof Error) {
-        setSearchError(err.message);
-      } else {
-        setSearchError("검색 실패");
-      }
+      setSearchError(err instanceof Error ? err.message : "검색 실패");
     } finally {
       setSearchLoading(false);
     }
@@ -53,156 +46,29 @@ const AdminUserPage = () => {
 
   return (
     <div>
-      <h1 className="text-x  l font-bold mb-4">
+      <h1 className="text-xl font-bold mb-4">
         {showBannedOnly
           ? "밴된 사용자 목록"
           : `전체 사용자 목록 (페이지 ${page + 1})`}
       </h1>
 
-      {/* 검색 영역 */}
-      <div className="flex items-center gap-2 mb-4">
-        <input
-          type="text"
-          placeholder="GlobalName으로 검색"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              handleSearch();
-            }
-          }}
-          className="px-2 py-1 border rounded text-black"
-        />
-        <Button
-          onClick={handleSearch}
-          className="bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 text-xs"
-        >
-          검색
-        </Button>
-        {search && (
-          <Button
-            onClick={handleClearSearch}
-            className="bg-gray-400 hover:bg-gray-500 text-white px-2 py-1 text-xs"
-          >
-            초기화
-          </Button>
-        )}
-      </div>
-      {searchLoading && <p>검색 중...</p>}
-      {searchError && <p className="text-red-500">{searchError}</p>}
-      {searchResult ? (
-        <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {searchResult.length === 0 ? (
-            <li className="text-white">검색 결과가 없습니다.</li>
-          ) : (
-            searchResult.map((user) => (
-              <li
-                key={user.userId}
-                className="bg-neutral-800 text-white rounded-lg p-4 shadow hover:ring-2 hover:ring-blue-400 transition"
-              >
-                <p className="text-lg font-semibold mb-1">{user.globalName}</p>
-                <p className="text-sm text-neutral-400">{user.userName}</p>
-                <p className="text-sm text-neutral-400">ID: {user.userId}</p>
-                <p className="text-sm text-neutral-400">
-                  Discord: {user.discordId}
-                </p>
-                <p className="text-sm text-neutral-400">
-                  역할: {user.role?.replace("ROLE_", "")}
-                </p>
-                <p className="text-sm text-neutral-400">
-                  신고당한 횟수: {user.reportedCount}
-                </p>
-                <p className="text-sm text-neutral-500 mt-1">
-                  가입일:{" "}
-                  {(() => {
-                    const koreaTime = convertToKoreaTime(user.createTime);
-                    return koreaTime.toLocaleString("ko-KR");
-                  })()}
-                </p>
-                <div className="flex justify-end">
-                  <Button
-                    onClick={() => navigate(`/profile/${user.userId}`)}
-                    className="px-2 py-1 h-6 text-xs bg-blue-500 hover:bg-blue-600 rounded text-white"
-                  >
-                    프로필 보기
-                  </Button>
-                </div>
-              </li>
-            ))
-          )}
-        </ul>
-      ) : (
-        <>
-          <Button
-            className="mb-4 bg-red-600 hover:bg-red-700 text-white text-sm px-3 py-1 rounded"
-            onClick={toggleBannedFilter}
-          >
-            {showBannedOnly ? "전체 사용자 보기" : "밴된 사용자만 보기"}
-          </Button>
+      <AdminUserSearchBar
+        search={search}
+        onChange={setSearch}
+        onSearch={handleSearch}
+        onClear={handleClearSearch}
+      />
 
-          {loading ? (
-            <p>로딩 중...</p>
-          ) : (
-            <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {usersToRender.map((user) =>
-                showBannedOnly ? (
-                  <BannedUserCard
-                    key={user.userId}
-                    user={user as BannedUserInfo}
-                  />
-                ) : (
-                  <li
-                    key={user.userId}
-                    className="bg-neutral-800 text-white rounded-lg p-4 shadow hover:ring-2 hover:ring-blue-400 transition"
-                  >
-                    <p className="text-lg font-semibold mb-1">
-                      {user.globalName}
-                    </p>
-                    <p className="text-sm text-neutral-400">{user.userName}</p>
-                    <p className="text-sm text-neutral-400">
-                      ID: {user.userId}
-                    </p>
-                    <p className="text-sm text-neutral-400">
-                      Discord: {user.discordId}
-                    </p>
-                    <p className="text-sm text-neutral-400">
-                      역할: {user.role.replace("ROLE_", "")}
-                    </p>
-                    <p className="text-sm text-neutral-400">
-                      신고당한 횟수: {user.reportedCount}
-                    </p>
-                    <p className="text-sm text-neutral-500 mt-1">
-                      가입일:{" "}
-                      {(() => {
-                        const koreaTime = convertToKoreaTime(user.createTime);
-                        return koreaTime.toLocaleString("ko-KR");
-                      })()}
-                    </p>
-                    <div className="flex justify-end">
-                      <Button
-                        onClick={() => navigate(`/profile/${user.userId}`)}
-                        className="px-2 py-1 h-6 text-xs bg-blue-500 hover:bg-blue-600 rounded text-white"
-                      >
-                        프로필 보기
-                      </Button>
-                    </div>
-                  </li>
-                )
-              )}
-            </ul>
-          )}
-
-          {/* 페이지네이션은 전체 목록일 때만 표시 */}
-          {!showBannedOnly && (
-            <div className="mt-4 space-x-2">
-              <button onClick={() => setPage((p) => Math.max(p - 1, 0))}>
-                이전
-              </button>
-              <button onClick={() => setPage((p) => p + 1)}>다음</button>
-            </div>
-          )}
-        </>
-      )}
+      <UserListSection
+        searchResult={searchResult}
+        searchLoading={searchLoading}
+        searchError={searchError}
+        usersToRender={usersToRender}
+        loading={loading}
+        showBannedOnly={showBannedOnly}
+        toggleBannedFilter={toggleBannedFilter}
+        setPage={setPage}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## 📝 개요
AdminUserPage가 비대해짐에 따라, 관심사를 나누고 컴포넌트를 분리하여 구조를 개선합니다.

## ✨ 상세 내용
- 검색 입력 영역 → `AdminUserSearchBar`로 분리
- 사용자 리스트 영역 → `UserListSection`으로 분리
- 사용자 정보 카드 → `UserCard`로 분리
- 전반적인 UI 구조 유지하며 코드 가독성과 유지보수성을 개선

## 📌 기타
- FSD 구조 내에서 `feature/admin/ui/` 하위에 컴포넌트 분리
- 이후 필요 시 각 컴포넌트를 테스트 가능하게 확장할 수 있음

## 🔗 관련 이슈
- close #225 