### PR TITLE
fix: 관리자가 거래글 삭제시 해당 거래글 작성자에게 티켓을 돌려주지 않던 문제 해결

### DIFF
--- a/backend/src/main/java/org/mapleland/maplelanbackserver/bot/BotCommandRegister.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/bot/BotCommandRegister.java
@@ -109,7 +109,7 @@ public class BotCommandRegister extends ListenerAdapter {
 
         //명령어 새로 등록 or 업데이트
         guild.upsertCommand("무릉도원", "무릉도원 지역 알람 등록")
-                .addOptions(aquariumOption)
+                .addOptions(muLungGardenOption)
                 .queue(cmd -> System.out.println("✅ /무릉도원 등록 완료"));
 
         OptionData victoriaOption = new OptionData(OptionType.STRING,"map","맵 이름을 선택하세요",true);

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
@@ -412,17 +412,16 @@ public class MapService {
         }
 
         int userId = JwtUtil.getUserId(token);
+        User jariUser = jari.getUser();
 
-        if (jari.getUser().getUserId() == userId || JwtUtil.getRole(token).equals("ROLE_ADMIN")) {
-            User user = userRepository.findByUserId(userId).orElseThrow(() -> new NotFoundUserException("사용자를 찾을 수 없음"));
-
+        if (jariUser.getUserId() == userId || JwtUtil.getRole(token).equals("ROLE_ADMIN")) {
             TradeType tradeType = jari.getTradeType();
             switch (tradeType) {
-                case BUY -> user.setBuyTicket(true);
-                case SELL -> user.setSellTicket(true);
+                case BUY -> jariUser.setBuyTicket(true);
+                case SELL -> jariUser.setSellTicket(true);
             }
 
-            userRepository.save(user);
+            userRepository.save(jariUser);
             jariRepository.delete(jari);
         } else throw new UserMismatchException("등록된 게시글과 다른 사용자 입니다.");
     }


### PR DESCRIPTION
## 📝 개요
현재 관리자가 거래글을 삭제 할 시
해당 거래글의 작성자에게 티켓을 돌려주지 않는 버그가 있었습니다. 이를 수정하였습니다.

## ✨ 상세 내용
* 거래글 삭제 API 요청자의 티켓 상태를 수정하는 것이 아닌, 거래글 작성자의 티켓 상태를 수정하도록 변경하였습니다.
* 무릉도원 옵션에 다른값이 들어가있었기에 이것도 겸사겸사 수정하였습니다.
  * `aquariumOption` -> `muLungGardenOption`

## 🔗 관련 이슈
This closes #233 
