### PR TITLE
chore: 디스코드 알림 설정 가이드 리뉴얼 및 안내 문구 개선

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,7 +37,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="유저가 직접 등록하고 거래하는 실시간 메랜 자리 거래 플랫폼"
+      content="유저가 직접 등록하고 거래하는 실시간 메랜 자리 거래 사이트"
     />
     <meta
       name="keywords"
@@ -49,7 +49,7 @@
     <meta property="og:title" content="메랜샵" />
     <meta
       property="og:description"
-      content="유저가 직접 등록하고 파는 메랜 자리 거래 플랫폼"
+      content="유저가 직접 등록하고 거래하는 실시간 메랜 자리 거래 사이트"
     />
     <meta property="og:image" content="/favicon.ico" />
     <meta property="og:url" content="https://mashop.kr/" />

--- a/frontend/src/feature/user/ui/UserWelcomeBox.tsx
+++ b/frontend/src/feature/user/ui/UserWelcomeBox.tsx
@@ -7,11 +7,12 @@ export const UserWelcomeBox = () => {
       className="self-start bg-[#5865F2] hover:bg-[#4752c4] text-white px-4 py-3 rounded-lg text-sm font-medium shadow transition cursor-pointer flex items-center gap-3"
     >
       <div className="flex-1 leading-snug">
-        <span className="text-white/90 text-xs sm:text-sm ">
+        <span className="text-white/90 text-xs sm:text-sm">
           자리 알림을 빠르게 받고 싶다면?{" "}
-          <span className="text-yellow-300 font-semibold ">
-            🔔 디스코드 알림 설정!
-          </span>
+          <span className="text-yellow-300 font-semibold">
+            🔔 새로워진 디스코드 알림 설정
+          </span>{" "}
+          확인하기!
         </span>
       </div>
     </Link>

--- a/frontend/src/page/notice/NotificationGuide.tsx
+++ b/frontend/src/page/notice/NotificationGuide.tsx
@@ -3,7 +3,7 @@ const NotificationGuide = () => {
     <div className="max-w-xl mx-auto py-12 px-6 text-white rounded-lg bg-neutral-700">
       <h1 className="text-2xl font-bold mb-6">🔔 디스코드 알림 설정 가이드</h1>
       <p className="mb-4 text-sm sm:text-base leading-relaxed">
-        자리 등록 알림을 받으려면 아래 세 단계를 완료해야 합니다:
+        자리 등록 알림을 받으려면 아래 세 단계를 완료해주세요:
       </p>
       <ol className="list-decimal ml-5 space-y-4 text-sm sm:text-base">
         <li>
@@ -32,19 +32,23 @@ const NotificationGuide = () => {
           옵션이 켜져 있는지 확인해주세요.
         </li>
         <li>
-          <strong>원하는 자리 알림 설정</strong>
+          <strong>디스코드 내 알림 설정</strong>
           <br />
+          디스코드 서버의{" "}
           <span className="text-yellow-300 font-semibold">
-            ⚠️ 월드 페이지가 아닌
+            #🔔｜알림받는-설정
           </span>{" "}
-          개별 <span className="font-semibold">자리 상세 페이지</span>에서{" "}
-          <span className="text-yellow-300 font-semibold">🔔 알림 받기</span>{" "}
-          버튼을 눌러주세요. 해당 자리에 새로운 등록이 생기면 디스코드 DM으로
-          알려드립니다.
+          채널에 접속하여 안내된 내용을 읽고,{" "}
+          <span className="text-yellow-300 font-semibold">
+            원하는 자리를 알림 설정
+          </span>
+          해주세요.
           <br />
-          <span className="text-xs text-neutral-300 italic mt-1 block">
-            ※ 최대 <span className="text-yellow-300 font-bold">2개</span>{" "}
-            자리까지 알림 설정이 가능합니다.
+          <span className="text-sm text-neutral-300 mt-1 block leading-relaxed">
+            설정이 완료되면 해당 자리에 새 글이 등록될 때{" "}
+            <span className="text-yellow-300 font-semibold">디스코드 DM</span>
+            으로 자동 알림을 받게 됩니다. 알림 설정은 언제든지 자유롭게
+            추가하거나 해제할 수 있어요.
           </span>
         </li>
       </ol>


### PR DESCRIPTION
## ✅ 개요
기존 "자리 상세 페이지 → 알림 받기 버튼" 방식에서,
디스코드 내 역할 선택 방식으로 알림 설정 플로우가 변경됨에 따라,
알림 설정 가이드 및 관련 UI 문구를 전면 개편합니다.

## ✨ 변경사항
- NotificationGuide 컴포넌트 내 3단계 설명 전면 수정
- "자리 상세 페이지 알림 버튼" 문구 제거
- 역할 설정 중심의 설명으로 통일
- UserWelcomeBox 문구도 "새로워진 디스코드 알림 설정" 강조로 개선

## 📌 참고
- 알림 설정은 디스코드 내 `#🔔｜알림받는-설정` 채널에서 역할 선택 방식으로 운영됨

## 🔗 관련 이슈
- close #241 
