### PR TITLE
Feature/admin trade completed count

### DIFF
--- a/backend/src/main/java/org/mapleland/maplelanbackserver/controller/admincontroller/AdminController.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/controller/admincontroller/AdminController.java
@@ -72,6 +72,12 @@ public class AdminController {
         return ResponseEntity.status(HttpStatus.OK).body(signupCountPerDay);
     }
 
+    @GetMapping("/api/admin/users/completed-count")
+    public ResponseEntity<List<CompletedTradeCountDto>> getCompletedTradeCountPerDay(@RequestParam int year, @RequestParam int month) {
+        List<CompletedTradeCountDto> completedTradeCountPerDay = mapService.getCompletedTradeCountPerDay(year, month);
+        return ResponseEntity.status(HttpStatus.OK).body(completedTradeCountPerDay);
+    }
+
     @GetMapping("/api/admin/users/banned")
     public ResponseEntity<List<ResponseBannedUserDto>> lockedUsers() {
         List<ResponseBannedUserDto> responseBannedUserDtos = userService.callLockedUser();

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/controller/admincontroller/AdminController.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/controller/admincontroller/AdminController.java
@@ -72,7 +72,7 @@ public class AdminController {
         return ResponseEntity.status(HttpStatus.OK).body(signupCountPerDay);
     }
 
-    @GetMapping("/api/admin/users/completed-count")
+    @GetMapping("/api/admin/trade/completed-count")
     public ResponseEntity<List<CompletedTradeCountDto>> getCompletedTradeCountPerDay(@RequestParam int year, @RequestParam int month) {
         List<CompletedTradeCountDto> completedTradeCountPerDay = mapService.getCompletedTradeCountPerDay(year, month);
         return ResponseEntity.status(HttpStatus.OK).body(completedTradeCountPerDay);

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/dto/response/CompletedTradeCountDto.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/dto/response/CompletedTradeCountDto.java
@@ -1,0 +1,6 @@
+package org.mapleland.maplelanbackserver.dto.response;
+
+import java.time.LocalDate;
+
+public record CompletedTradeCountDto(LocalDate completionTime, Long count) {
+} 

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/repository/JariRepository.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/repository/JariRepository.java
@@ -120,6 +120,16 @@ FROM Jari j ORDER BY j.createTime desc
 
     Optional<Jari> findByUser_UserIdAndUserMapId(Integer userId, Integer mapId);
 
-
+    @Query("""
+    SELECT FUNCTION('DATE', j.updateTime), COUNT(j)
+    FROM Jari j
+    WHERE j.updateTime BETWEEN :start AND :end
+      AND j.isCompleted = true
+    GROUP BY FUNCTION('DATE', j.updateTime)
+""")
+    List<Object[]> countCompletedTradeByUpdateDateBetweenGroupByDay(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 
 }

--- a/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
+++ b/backend/src/main/java/org/mapleland/maplelanbackserver/service/MapService.java
@@ -9,6 +9,7 @@ import org.mapleland.maplelanbackserver.dto.request.JariUpdateRequest;
 import org.mapleland.maplelanbackserver.dto.request.JariIsCompletedRequest;
 import org.mapleland.maplelanbackserver.dto.response.JariListResponse;
 import org.mapleland.maplelanbackserver.dto.response.PriceStatDto;
+import org.mapleland.maplelanbackserver.dto.response.CompletedTradeCountDto;
 import org.mapleland.maplelanbackserver.dto.update.PriceUpdateRequest;
 import org.mapleland.maplelanbackserver.dto.update.ServerColorRequest;
 import org.mapleland.maplelanbackserver.enumType.Region;
@@ -36,7 +37,9 @@ import org.springframework.stereotype.Service;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.LocalDate;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.time.LocalDateTime;
 
 @Service
@@ -489,5 +492,33 @@ public class MapService {
     public JariListResponse findAllJari(Pageable pageable) {
         Page<JariResponse> jariResponsePage = jariRepository.findAll(pageable).map(JariResponse::from);
         return JariListResponse.from(jariResponsePage);
+    }
+
+    public List<CompletedTradeCountDto> getCompletedTradeCountPerDay(int year, int month) {
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+        LocalDateTime start = startDate.atStartOfDay(); // 00:00:00
+        LocalDateTime end = endDate.atTime(23, 59, 59); // 23:59:59
+
+        // DB 조회 - 완료된 거래만 조회
+        List<Object[]> result = jariRepository.countCompletedTradeByUpdateDateBetweenGroupByDay(start, end);
+
+        // 결과 맵 초기화 - 해당 월의 모든 날짜를 0으로 초기화
+        Map<LocalDate, Long> map = new LinkedHashMap<>();
+        for (int i = 0; i < startDate.lengthOfMonth(); i++) {
+            map.put(startDate.plusDays(i), 0L);
+        }
+
+        for (Object[] row : result) {
+            java.sql.Date sqlDate = (java.sql.Date) row[0];
+            LocalDate date = sqlDate.toLocalDate();
+            Long count = (Long) row[1];
+            map.put(date, count);
+        }
+
+        return map.entrySet().stream()
+                .map(entry -> new CompletedTradeCountDto(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📝 개요
관리자 페이지에서 일별 거래 완료 통계를 조회할 수 있는 API를 추가

## ✨ 상세 내용
엔드포인트: GET /api/admin/trade/completed-count?year=2025&month=1
권한: ADMIN
응답: 지정된 월의 모든 날짜별 거래 완료 건수
<img width="841" height="689" alt="image" src="https://github.com/user-attachments/assets/8159d041-b773-4c72-97df-2c256f1fa352" />

## 📌 기타
updateTime 기준으로 조회

## 🔗 관련 이슈
이슈번호, 관련 링크 등
